### PR TITLE
feat(workers): poll-x processor (#7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,14 +26,14 @@ Hexagonal (ports & adapters) with NestJS DI. Three swap-point interfaces: **XSou
 
 ### Module Dependency Order
 
-`LoggerModule → AppwriteModule → QueueModule → UsersRepoModule (global) → ScheduleModule (global) → feature modules (Auth, Users, Ingestion, Health)`
+`LoggerModule → AppwriteModule → QueueModule → UsersRepoModule (global) → ScheduleModule (global) → feature modules (Auth, Users, Ingestion, Workers, Health)`
 
 All modules use a static `.forRoot(env: Env)` factory receiving the validated env config.
 
 ### Key Rules
 
 - **Domain layer never imports infrastructure.** No BullMQ types, Appwrite SDK types, or NestJS decorators in domain code.
-- **BullMQ + ioredis types confined to `src/queue/` and `src/schedule/`** — everything else uses string DI tokens.
+- **BullMQ + ioredis types confined to `src/queue/`, `src/schedule/`, and `src/workers/`** — everything else uses string DI tokens.
 - **Repos return plain TypeScript shapes**, never Appwrite `Models.Document<T>` envelopes.
 - **All external I/O goes through a port interface** — never call X API, Firecrawl, OpenRouter, or Appwrite directly from domain code.
 - **Long-running work belongs in BullMQ processors**, never on the HTTP request path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+x-reporter is a multi-user service that polls a user's X (Twitter) likes/bookmarks, extracts linked articles, and builds AI-generated digests. Stack: **Bun + NestJS + Appwrite + BullMQ/Redis + LangGraph + OpenRouter**.
+
+## Commands
+
+```bash
+bun run start:dev          # dev server with watch
+bun run start              # production start
+bun run build              # bundle to dist/
+bun test                   # run all tests
+bun test src/path/file.test.ts  # single test file
+bunx biome lint .          # lint
+bunx biome format --write .  # format
+bunx tsc --noEmit          # typecheck
+bun run setup:appwrite     # bootstrap Appwrite collections
+```
+
+## Architecture
+
+Hexagonal (ports & adapters) with NestJS DI. Three swap-point interfaces: **XSource**, **ArticleExtractor**, **LlmProvider** (defined as ports — see `docs/interfaces.md`).
+
+### Module Dependency Order
+
+`LoggerModule → AppwriteModule → QueueModule → UsersRepoModule (global) → ScheduleModule (global) → feature modules (Auth, Users, Ingestion, Health)`
+
+All modules use a static `.forRoot(env: Env)` factory receiving the validated env config.
+
+### Key Rules
+
+- **Domain layer never imports infrastructure.** No BullMQ types, Appwrite SDK types, or NestJS decorators in domain code.
+- **BullMQ + ioredis types confined to `src/queue/` and `src/schedule/`** — everything else uses string DI tokens.
+- **Repos return plain TypeScript shapes**, never Appwrite `Models.Document<T>` envelopes.
+- **All external I/O goes through a port interface** — never call X API, Firecrawl, OpenRouter, or Appwrite directly from domain code.
+- **Long-running work belongs in BullMQ processors**, never on the HTTP request path.
+- **Validate external input with zod** at HTTP and queue boundaries.
+- **Prefer Bun-native crypto and fetch** over Node polyfills.
+
+### Config & Secrets
+
+- Env validated at boot via zod schema in `src/config/env.ts` — `loadEnv()` runs before `NestFactory.create`.
+- Token encryption: AES-256-GCM via `TOKEN_ENC_KEY` (base64-encoded 32 bytes).
+- Path alias: `~/*` maps to `./src/*`.
+
+### Data (Appwrite)
+
+Collections: `users`, `tokens`, `items`, `articles`, `digests`. Schema details in `docs/data-model.md`. When changing schema, update both `docs/data-model.md` and `scripts/setup-appwrite.ts` in the same PR.
+
+## Delivery Conventions
+
+- **Conventional Commits** for PR titles: `feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`
+- **Branch names**: `feat/<slug>`, `fix/<slug>`, `chore/<slug>`, `docs/<slug>`
+- One milestone issue = one branch = one PR. Don't bundle milestones.
+- Bump `package.json` version in the same PR as the change.
+- PR body must include an acceptance-criteria checklist mirroring the linked issue.
+- When adding a port or adapter, update `docs/interfaces.md` in the same PR.
+- Keep `docs/` as source of truth — update relevant docs alongside code changes.
+
+## Formatting (Biome)
+
+- 100-column line width, 2-space indent, single quotes, trailing commas.

--- a/docs/specs/plans/2026-04-13-poll-x-processor.md
+++ b/docs/specs/plans/2026-04-13-poll-x-processor.md
@@ -1,0 +1,1481 @@
+# Poll-X Processor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the first BullMQ worker — a `PollXProcessor` that consumes the `poll-x` queue, fetches a user's likes/bookmarks via `XSource`, upserts items, and enqueues extraction jobs.
+
+**Architecture:** New `WorkersModule` owns the BullMQ `Worker` lifecycle. `PollXProcessor` is a plain injectable with no BullMQ types in its public interface. A new `ItemsRepo` handles item persistence. `UsersRepo` gains cursor fields and an `updateCursors` method.
+
+**Tech Stack:** NestJS, BullMQ (Worker), Appwrite (items collection), Bun test
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `src/users/users.repo.ts` | Add cursor fields to `UserRecord`, add `updateCursors` method |
+| Modify | `src/users/users.repo.test.ts` | Tests for cursor fields and `updateCursors` |
+| Create | `src/workers/items.repo.ts` | Appwrite adapter for `items` collection |
+| Create | `src/workers/items.repo.test.ts` | Tests for `ItemsRepo` |
+| Create | `src/workers/poll-x.processor.ts` | Processing logic for `poll-x` queue |
+| Create | `src/workers/poll-x.processor.test.ts` | Unit tests with stub XSource |
+| Create | `src/workers/workers.module.ts` | Module owning Worker lifecycle |
+| Modify | `src/app.module.ts` | Register `WorkersModule` |
+| Modify | `package.json` | Version bump 0.6.0 → 0.7.0 |
+
+---
+
+### Task 1: Add cursor fields to UserRecord
+
+**Files:**
+- Modify: `src/users/users.repo.ts`
+- Modify: `src/users/users.repo.test.ts`
+
+- [ ] **Step 1: Write failing tests for cursor fields on UserRecord**
+
+Add to `src/users/users.repo.test.ts` at the end of the `UsersRepo.findById` describe block:
+
+```ts
+it('surfaces stored cursor values when present on the row', async () => {
+  const { repo, db } = makeRepo();
+  const created = await repo.upsertByXUserId({ xUserId: '12345', handle: 'h' });
+  const stored = db.docs.get(created.id);
+  if (!stored) throw new Error('seeded row missing');
+  stored.lastLikeCursor = 'abc123';
+  stored.lastBookmarkCursor = 'def456';
+  const found = await repo.findById(created.id);
+  expect(found).not.toBeNull();
+  expect((found as UserRecord).lastLikeCursor).toBe('abc123');
+  expect((found as UserRecord).lastBookmarkCursor).toBe('def456');
+});
+
+it('leaves cursors undefined when the row has never been polled', async () => {
+  const { repo } = makeRepo();
+  const created = await repo.upsertByXUserId({ xUserId: '12345', handle: 'h' });
+  const found = await repo.findById(created.id);
+  expect(found).not.toBeNull();
+  expect((found as UserRecord).lastLikeCursor).toBeUndefined();
+  expect((found as UserRecord).lastBookmarkCursor).toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/users/users.repo.test.ts`
+Expected: Two failures — `lastLikeCursor` and `lastBookmarkCursor` are not on `UserRecord`.
+
+- [ ] **Step 3: Add cursor fields to UserRecord and toUserRecord**
+
+In `src/users/users.repo.ts`, add to the `UserRecord` interface after `digestIntervalMin`:
+
+```ts
+  /** Opaque X pagination cursor for likes. Set by poll-x processor. */
+  lastLikeCursor?: string;
+  /** Opaque X pagination cursor for bookmarks. Set by poll-x processor. */
+  lastBookmarkCursor?: string;
+```
+
+In the `toUserRecord` function, before the `return` statement, add:
+
+```ts
+  const lastLikeCursor = optionalStringField(doc, 'lastLikeCursor');
+  const lastBookmarkCursor = optionalStringField(doc, 'lastBookmarkCursor');
+```
+
+And update the return to spread them:
+
+```ts
+  return {
+    id: doc.$id,
+    xUserId,
+    handle,
+    status,
+    createdAt,
+    ...(pollIntervalMin !== undefined ? { pollIntervalMin } : {}),
+    ...(digestIntervalMin !== undefined ? { digestIntervalMin } : {}),
+    ...(lastLikeCursor !== undefined ? { lastLikeCursor } : {}),
+    ...(lastBookmarkCursor !== undefined ? { lastBookmarkCursor } : {}),
+  };
+```
+
+Add the helper function after `optionalIntegerField`:
+
+```ts
+function optionalStringField(
+  doc: Record<string, unknown> & { $id: string },
+  key: string,
+): string | undefined {
+  const value = doc[key];
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== 'string') {
+    throw new Error(`users row ${doc.$id} has non-string ${key}: ${String(value)}`);
+  }
+  return value;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/users/users.repo.test.ts`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/users/users.repo.ts src/users/users.repo.test.ts
+git commit -m "feat(users): add cursor fields to UserRecord"
+```
+
+---
+
+### Task 2: Add UsersRepo.updateCursors method
+
+**Files:**
+- Modify: `src/users/users.repo.ts`
+- Modify: `src/users/users.repo.test.ts`
+
+- [ ] **Step 1: Write failing tests for updateCursors**
+
+Add a new describe block at the end of `src/users/users.repo.test.ts`:
+
+```ts
+describe('UsersRepo.updateCursors', () => {
+  it('writes lastLikeCursor and returns the updated record', async () => {
+    const { repo } = makeRepo();
+    const u = await repo.upsertByXUserId({ xUserId: '12345', handle: 'h' });
+    const updated = await repo.updateCursors(u.id, { lastLikeCursor: 'cursor-abc' });
+    expect(updated.id).toBe(u.id);
+    expect(updated.lastLikeCursor).toBe('cursor-abc');
+    expect(updated.lastBookmarkCursor).toBeUndefined();
+  });
+
+  it('writes lastBookmarkCursor and returns the updated record', async () => {
+    const { repo } = makeRepo();
+    const u = await repo.upsertByXUserId({ xUserId: '12345', handle: 'h' });
+    const updated = await repo.updateCursors(u.id, { lastBookmarkCursor: 'cursor-xyz' });
+    expect(updated.lastBookmarkCursor).toBe('cursor-xyz');
+  });
+
+  it('writes both cursors when both are supplied', async () => {
+    const { repo } = makeRepo();
+    const u = await repo.upsertByXUserId({ xUserId: '12345', handle: 'h' });
+    const updated = await repo.updateCursors(u.id, {
+      lastLikeCursor: 'lc',
+      lastBookmarkCursor: 'bc',
+    });
+    expect(updated.lastLikeCursor).toBe('lc');
+    expect(updated.lastBookmarkCursor).toBe('bc');
+  });
+
+  it('leaves an unspecified cursor untouched on a partial patch', async () => {
+    const { repo, db } = makeRepo();
+    const u = await repo.upsertByXUserId({ xUserId: '12345', handle: 'h' });
+    await repo.updateCursors(u.id, { lastLikeCursor: 'lc', lastBookmarkCursor: 'bc' });
+    const after = await repo.updateCursors(u.id, { lastLikeCursor: 'lc2' });
+    expect(after.lastLikeCursor).toBe('lc2');
+    expect(after.lastBookmarkCursor).toBe('bc');
+    const stored = db.docs.get(u.id);
+    expect(stored?.lastBookmarkCursor).toBe('bc');
+  });
+
+  it('throws when the user does not exist', async () => {
+    const { repo } = makeRepo();
+    await expect(
+      repo.updateCursors('does-not-exist', { lastLikeCursor: 'x' }),
+    ).rejects.toThrow();
+  });
+
+  it('throws on an empty patch', async () => {
+    const { repo } = makeRepo();
+    const u = await repo.upsertByXUserId({ xUserId: '12345', handle: 'h' });
+    await expect(repo.updateCursors(u.id, {})).rejects.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/users/users.repo.test.ts`
+Expected: Failures — `updateCursors` does not exist on `UsersRepo`.
+
+- [ ] **Step 3: Implement updateCursors**
+
+Add to `src/users/users.repo.ts`, in the `UsersRepo` class after the `updateCadence` method. Also add `UpdateCursorsInput` interface after `UpdateCadenceInput`:
+
+```ts
+export interface UpdateCursorsInput {
+  lastLikeCursor?: string;
+  lastBookmarkCursor?: string;
+}
+```
+
+Method:
+
+```ts
+  /**
+   * Update one or both pagination cursors. Called by the poll-x processor
+   * after items are persisted. Throws if the user does not exist (a cursor
+   * update on a missing user is a bug, not a race condition).
+   */
+  async updateCursors(
+    userId: string,
+    patch: UpdateCursorsInput,
+  ): Promise<UserRecord> {
+    const data: Record<string, unknown> = {};
+    if (patch.lastLikeCursor !== undefined) {
+      data.lastLikeCursor = patch.lastLikeCursor;
+    }
+    if (patch.lastBookmarkCursor !== undefined) {
+      data.lastBookmarkCursor = patch.lastBookmarkCursor;
+    }
+    if (Object.keys(data).length === 0) {
+      throw new Error('updateCursors called with empty patch');
+    }
+    const updated = await this.db.updateDocument({
+      databaseId: this.databaseId,
+      collectionId: COLLECTION_ID,
+      documentId: userId,
+      data,
+    });
+    return toUserRecord(updated);
+  }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/users/users.repo.test.ts`
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/users/users.repo.ts src/users/users.repo.test.ts
+git commit -m "feat(users): add updateCursors method to UsersRepo"
+```
+
+---
+
+### Task 3: Create ItemsRepo
+
+**Files:**
+- Create: `src/workers/items.repo.ts`
+- Create: `src/workers/items.repo.test.ts`
+
+- [ ] **Step 1: Write the ItemsRepo test file with FakeDatabases**
+
+Create `src/workers/items.repo.test.ts`:
+
+```ts
+import { describe, expect, it } from 'bun:test';
+import { ItemsRepo, type ItemRecord } from './items.repo';
+
+/**
+ * In-memory fake of the Appwrite databases slice that `ItemsRepo` uses.
+ * Mirrors the compound unique index `(userId, xTweetId)` from the real
+ * schema by checking for duplicates on create.
+ */
+class FakeDatabases {
+  readonly docs = new Map<string, Record<string, unknown> & { $id: string }>();
+
+  async createDocument(params: {
+    databaseId: string;
+    collectionId: string;
+    documentId: string;
+    data: Record<string, unknown>;
+  }): Promise<Record<string, unknown> & { $id: string }> {
+    // Enforce compound unique index (userId, xTweetId).
+    const userId = params.data.userId;
+    const xTweetId = params.data.xTweetId;
+    if (typeof userId === 'string' && typeof xTweetId === 'string') {
+      for (const doc of this.docs.values()) {
+        if (doc.userId === userId && doc.xTweetId === xTweetId) {
+          const err = new Error('document already exists') as Error & { code: number };
+          err.code = 409;
+          throw err;
+        }
+      }
+    }
+    if (this.docs.has(params.documentId)) {
+      const err = new Error('document already exists') as Error & { code: number };
+      err.code = 409;
+      throw err;
+    }
+    const doc = { $id: params.documentId, ...params.data };
+    this.docs.set(params.documentId, doc);
+    return doc;
+  }
+
+  async getDocument(params: {
+    databaseId: string;
+    collectionId: string;
+    documentId: string;
+  }): Promise<Record<string, unknown> & { $id: string }> {
+    const doc = this.docs.get(params.documentId);
+    if (!doc) {
+      const err = new Error('not found') as Error & { code: number };
+      err.code = 404;
+      throw err;
+    }
+    return doc;
+  }
+}
+
+function makeRepo(): { repo: ItemsRepo; db: FakeDatabases } {
+  const db = new FakeDatabases();
+  const fakeAppwrite = {
+    databaseId: 'test-db',
+    databases: db as unknown as never,
+  };
+  return { repo: new ItemsRepo(fakeAppwrite as never), db };
+}
+
+describe('ItemsRepo.upsertMany', () => {
+  it('creates new items and marks them as isNew', async () => {
+    const { repo } = makeRepo();
+    const results = await repo.upsertMany('user1', [
+      {
+        tweetId: 'tweet1',
+        text: 'hello world',
+        authorHandle: 'alice',
+        urls: ['https://example.com'],
+        kind: 'like',
+      },
+    ]);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.isNew).toBe(true);
+    expect(typeof results[0]!.id).toBe('string');
+  });
+
+  it('marks duplicate items as not new on second upsert', async () => {
+    const { repo } = makeRepo();
+    const items = [
+      {
+        tweetId: 'tweet1',
+        text: 'hello',
+        authorHandle: 'alice',
+        urls: [],
+        kind: 'like' as const,
+      },
+    ];
+    const first = await repo.upsertMany('user1', items);
+    expect(first[0]!.isNew).toBe(true);
+    const second = await repo.upsertMany('user1', items);
+    expect(second[0]!.isNew).toBe(false);
+    expect(second[0]!.id).toBe(first[0]!.id);
+  });
+
+  it('handles a mix of new and existing items', async () => {
+    const { repo } = makeRepo();
+    await repo.upsertMany('user1', [
+      { tweetId: 't1', text: 'a', authorHandle: 'a', urls: [], kind: 'like' },
+    ]);
+    const results = await repo.upsertMany('user1', [
+      { tweetId: 't1', text: 'a', authorHandle: 'a', urls: [], kind: 'like' },
+      { tweetId: 't2', text: 'b', authorHandle: 'b', urls: [], kind: 'bookmark' },
+    ]);
+    expect(results).toHaveLength(2);
+    expect(results[0]!.isNew).toBe(false);
+    expect(results[1]!.isNew).toBe(true);
+  });
+
+  it('sets enriched to false on new items', async () => {
+    const { repo, db } = makeRepo();
+    const results = await repo.upsertMany('user1', [
+      { tweetId: 't1', text: 'a', authorHandle: 'a', urls: [], kind: 'like' },
+    ]);
+    const doc = db.docs.get(results[0]!.id);
+    expect(doc?.enriched).toBe(false);
+  });
+
+  it('sets fetchedAt to an ISO timestamp on new items', async () => {
+    const { repo, db } = makeRepo();
+    const before = new Date().toISOString();
+    const results = await repo.upsertMany('user1', [
+      { tweetId: 't1', text: 'a', authorHandle: 'a', urls: [], kind: 'like' },
+    ]);
+    const doc = db.docs.get(results[0]!.id);
+    expect(typeof doc?.fetchedAt).toBe('string');
+    expect(doc!.fetchedAt! >= before).toBe(true);
+  });
+
+  it('returns empty array for empty input', async () => {
+    const { repo } = makeRepo();
+    const results = await repo.upsertMany('user1', []);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows the same tweetId for different users', async () => {
+    const { repo } = makeRepo();
+    const r1 = await repo.upsertMany('user1', [
+      { tweetId: 't1', text: 'a', authorHandle: 'a', urls: [], kind: 'like' },
+    ]);
+    const r2 = await repo.upsertMany('user2', [
+      { tweetId: 't1', text: 'a', authorHandle: 'a', urls: [], kind: 'like' },
+    ]);
+    expect(r1[0]!.isNew).toBe(true);
+    expect(r2[0]!.isNew).toBe(true);
+    expect(r1[0]!.id).not.toBe(r2[0]!.id);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/workers/items.repo.test.ts`
+Expected: Failure — module `./items.repo` not found.
+
+- [ ] **Step 3: Implement ItemsRepo**
+
+Create `src/workers/items.repo.ts`:
+
+```ts
+import { Injectable } from '@nestjs/common';
+import { ID } from 'node-appwrite';
+import { AppwriteService } from '../appwrite/appwrite.service';
+import type { TweetItem, TweetKind } from '../ingestion/x-source.port';
+
+export interface ItemRecord {
+  id: string;
+  userId: string;
+  xTweetId: string;
+  kind: TweetKind;
+  text: string;
+  authorHandle: string;
+  urls: string[];
+  fetchedAt: string;
+  enriched: boolean;
+}
+
+interface ItemsDatabases {
+  getDocument(params: {
+    databaseId: string;
+    collectionId: string;
+    documentId: string;
+  }): Promise<Record<string, unknown> & { $id: string }>;
+  createDocument(params: {
+    databaseId: string;
+    collectionId: string;
+    documentId: string;
+    data: Record<string, unknown>;
+  }): Promise<Record<string, unknown> & { $id: string }>;
+}
+
+const COLLECTION_ID = 'items';
+
+@Injectable()
+export class ItemsRepo {
+  private readonly databaseId: string;
+  private readonly db: ItemsDatabases;
+
+  constructor(appwrite: AppwriteService) {
+    this.databaseId = appwrite.databaseId;
+    this.db = appwrite.databases as unknown as ItemsDatabases;
+  }
+
+  /**
+   * Upsert items for a user. Uses `ID.unique()` for document IDs and
+   * relies on the compound unique index `(userId, xTweetId)` for dedup.
+   * On 409 conflict, the item already exists — look it up and return
+   * with `isNew: false`.
+   */
+  async upsertMany(
+    userId: string,
+    items: TweetItem[],
+  ): Promise<Array<{ id: string; isNew: boolean }>> {
+    const results: Array<{ id: string; isNew: boolean }> = [];
+    const fetchedAt = new Date().toISOString();
+
+    for (const item of items) {
+      try {
+        const created = await this.db.createDocument({
+          databaseId: this.databaseId,
+          collectionId: COLLECTION_ID,
+          documentId: ID.unique(),
+          data: {
+            userId,
+            xTweetId: item.tweetId,
+            kind: item.kind,
+            text: item.text,
+            authorHandle: item.authorHandle,
+            urls: item.urls,
+            fetchedAt,
+            enriched: false,
+          },
+        });
+        results.push({ id: created.$id, isNew: true });
+      } catch (err) {
+        if (!isConflict(err)) throw err;
+        // Item already exists — find it to get its ID.
+        const existing = await this.findByUserAndTweetId(userId, item.tweetId);
+        if (!existing) {
+          // 409 but can't find the doc — the conflict wasn't the compound
+          // index we expected. Surface the original error.
+          throw err;
+        }
+        results.push({ id: existing.id, isNew: false });
+      }
+    }
+    return results;
+  }
+
+  /**
+   * Find an item by userId + xTweetId. Used internally for conflict
+   * resolution on upsert. Returns `null` if not found.
+   *
+   * Since there's no way to getDocument by a compound index directly in
+   * Appwrite, we need to use listDocuments. However, to keep the
+   * structural interface minimal, we use a workaround: scan all docs
+   * in-memory in tests. In production, this is backed by the real
+   * Appwrite SDK which supports queries. For now, we do a simple
+   * approach: the 409 handler already knows the item exists, so we can
+   * search through the collection.
+   *
+   * NOTE: This method uses listDocuments which requires adding it to
+   * the structural interface. Instead, we keep the interface minimal and
+   * handle this in the upsert by storing a local map of created IDs.
+   */
+  async findByUserAndTweetId(
+    _userId: string,
+    _xTweetId: string,
+  ): Promise<ItemRecord | null> {
+    // This method is not needed in the hot path — the upsert uses a
+    // different approach. Placeholder for future milestone use.
+    return null;
+  }
+}
+
+function isConflict(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  return (err as { code?: number }).code === 409;
+}
+
+function toItemRecord(doc: Record<string, unknown> & { $id: string }): ItemRecord {
+  const userId = doc.userId;
+  const xTweetId = doc.xTweetId;
+  const kind = doc.kind;
+  const text = doc.text;
+  const authorHandle = doc.authorHandle;
+  const urls = doc.urls;
+  const fetchedAt = doc.fetchedAt;
+  const enriched = doc.enriched;
+  if (
+    typeof userId !== 'string' ||
+    typeof xTweetId !== 'string' ||
+    typeof text !== 'string' ||
+    typeof authorHandle !== 'string' ||
+    typeof fetchedAt !== 'string'
+  ) {
+    throw new Error(`items row ${doc.$id} is missing required string fields`);
+  }
+  if (kind !== 'like' && kind !== 'bookmark') {
+    throw new Error(`items row ${doc.$id} has invalid kind: ${String(kind)}`);
+  }
+  if (!Array.isArray(urls)) {
+    throw new Error(`items row ${doc.$id} has non-array urls`);
+  }
+  return {
+    id: doc.$id,
+    userId,
+    xTweetId,
+    kind,
+    text,
+    authorHandle,
+    urls: urls.map(String),
+    fetchedAt,
+    enriched: enriched === true,
+  };
+}
+```
+
+Wait — the `findByUserAndTweetId` approach is problematic. The 409 conflict handler needs to find the existing document's ID. Let me rethink.
+
+Actually, I'll take a simpler approach: track a local `Map<string, string>` inside `upsertMany` for items we've already created in this batch, and for 409 conflicts, use `listDocuments` with a query. Let me add `listDocuments` to the structural interface.
+
+Let me rewrite this properly.
+
+Create `src/workers/items.repo.ts`:
+
+```ts
+import { Injectable } from '@nestjs/common';
+import { ID, Query } from 'node-appwrite';
+import { AppwriteService } from '../appwrite/appwrite.service';
+import type { TweetItem, TweetKind } from '../ingestion/x-source.port';
+
+export interface ItemRecord {
+  id: string;
+  userId: string;
+  xTweetId: string;
+  kind: TweetKind;
+  text: string;
+  authorHandle: string;
+  urls: string[];
+  fetchedAt: string;
+  enriched: boolean;
+}
+
+interface ItemsDatabases {
+  createDocument(params: {
+    databaseId: string;
+    collectionId: string;
+    documentId: string;
+    data: Record<string, unknown>;
+  }): Promise<Record<string, unknown> & { $id: string }>;
+  listDocuments(params: {
+    databaseId: string;
+    collectionId: string;
+    queries?: string[];
+  }): Promise<{ total: number; documents: Array<Record<string, unknown> & { $id: string }> }>;
+}
+
+const COLLECTION_ID = 'items';
+
+@Injectable()
+export class ItemsRepo {
+  private readonly databaseId: string;
+  private readonly db: ItemsDatabases;
+
+  constructor(appwrite: AppwriteService) {
+    this.databaseId = appwrite.databaseId;
+    this.db = appwrite.databases as unknown as ItemsDatabases;
+  }
+
+  /**
+   * Upsert items for a user. Uses `ID.unique()` for document IDs and
+   * relies on the compound unique index `(userId, xTweetId)` for dedup.
+   * On 409 conflict, the item already exists — query it back and return
+   * with `isNew: false`.
+   */
+  async upsertMany(
+    userId: string,
+    items: TweetItem[],
+  ): Promise<Array<{ id: string; isNew: boolean }>> {
+    const results: Array<{ id: string; isNew: boolean }> = [];
+    const fetchedAt = new Date().toISOString();
+
+    for (const item of items) {
+      try {
+        const created = await this.db.createDocument({
+          databaseId: this.databaseId,
+          collectionId: COLLECTION_ID,
+          documentId: ID.unique(),
+          data: {
+            userId,
+            xTweetId: item.tweetId,
+            kind: item.kind,
+            text: item.text,
+            authorHandle: item.authorHandle,
+            urls: item.urls,
+            fetchedAt,
+            enriched: false,
+          },
+        });
+        results.push({ id: created.$id, isNew: true });
+      } catch (err) {
+        if (!isConflict(err)) throw err;
+        const existing = await this.findByUserAndTweetId(userId, item.tweetId);
+        if (!existing) throw err;
+        results.push({ id: existing.id, isNew: false });
+      }
+    }
+    return results;
+  }
+
+  /** Query by compound key. Returns `null` on miss. */
+  async findByUserAndTweetId(
+    userId: string,
+    xTweetId: string,
+  ): Promise<ItemRecord | null> {
+    const result = await this.db.listDocuments({
+      databaseId: this.databaseId,
+      collectionId: COLLECTION_ID,
+      queries: [Query.equal('userId', userId), Query.equal('xTweetId', xTweetId)],
+    });
+    if (result.total === 0 || result.documents.length === 0) return null;
+    return toItemRecord(result.documents[0]!);
+  }
+}
+
+function isConflict(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  return (err as { code?: number }).code === 409;
+}
+
+function toItemRecord(doc: Record<string, unknown> & { $id: string }): ItemRecord {
+  const userId = doc.userId;
+  const xTweetId = doc.xTweetId;
+  const kind = doc.kind;
+  const text = doc.text;
+  const authorHandle = doc.authorHandle;
+  const urls = doc.urls;
+  const fetchedAt = doc.fetchedAt;
+  const enriched = doc.enriched;
+  if (
+    typeof userId !== 'string' ||
+    typeof xTweetId !== 'string' ||
+    typeof text !== 'string' ||
+    typeof authorHandle !== 'string' ||
+    typeof fetchedAt !== 'string'
+  ) {
+    throw new Error(`items row ${doc.$id} is missing required string fields`);
+  }
+  if (kind !== 'like' && kind !== 'bookmark') {
+    throw new Error(`items row ${doc.$id} has invalid kind: ${String(kind)}`);
+  }
+  if (!Array.isArray(urls)) {
+    throw new Error(`items row ${doc.$id} has non-array urls`);
+  }
+  return {
+    id: doc.$id,
+    userId,
+    xTweetId,
+    kind,
+    text,
+    authorHandle,
+    urls: urls.map(String),
+    fetchedAt,
+    enriched: enriched === true,
+  };
+}
+```
+
+- [ ] **Step 4: Update the test fake to support listDocuments**
+
+The test `FakeDatabases` needs a `listDocuments` that supports `Query.equal` filtering. Update the test file's `FakeDatabases` class to add:
+
+```ts
+  async listDocuments(params: {
+    databaseId: string;
+    collectionId: string;
+    queries?: string[];
+  }): Promise<{ total: number; documents: Array<Record<string, unknown> & { $id: string }> }> {
+    const filters: Array<[string, string]> = (params.queries ?? []).map((q) => {
+      const parsed = parseEqualQuery(q);
+      if (!parsed) throw new Error(`unsupported fake query: ${q}`);
+      return parsed;
+    });
+    const all = Array.from(this.docs.values());
+    const matched = all.filter((d) =>
+      filters.every(([field, value]) => String(d[field]) === value),
+    );
+    return { total: matched.length, documents: matched };
+  }
+```
+
+And add the `parseEqualQuery` helper (same as in `users.repo.test.ts`):
+
+```ts
+function parseEqualQuery(q: string): [string, string] | null {
+  try {
+    const parsed = JSON.parse(q) as {
+      method?: unknown;
+      attribute?: unknown;
+      values?: unknown;
+    };
+    if (parsed.method !== 'equal') return null;
+    if (typeof parsed.attribute !== 'string') return null;
+    if (!Array.isArray(parsed.values) || parsed.values.length === 0) return null;
+    return [parsed.attribute, String(parsed.values[0])];
+  } catch {
+    return null;
+  }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bun test src/workers/items.repo.test.ts`
+Expected: All tests pass.
+
+- [ ] **Step 6: Run typecheck**
+
+Run: `bunx tsc --noEmit`
+Expected: Clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/workers/items.repo.ts src/workers/items.repo.test.ts
+git commit -m "feat(workers): add ItemsRepo for items collection"
+```
+
+---
+
+### Task 4: Create PollXProcessor
+
+**Files:**
+- Create: `src/workers/poll-x.processor.ts`
+- Create: `src/workers/poll-x.processor.test.ts`
+
+- [ ] **Step 1: Write the test file with fakes and the first test**
+
+Create `src/workers/poll-x.processor.test.ts`:
+
+```ts
+import { describe, expect, it } from 'bun:test';
+import { AuthExpiredError } from '../auth/auth.service';
+import type { FetchPage, TweetItem, XSource } from '../ingestion/x-source.port';
+import type { UserRecord } from '../users/users.repo';
+import { PollXProcessor } from './poll-x.processor';
+import type { ItemRecord } from './items.repo';
+
+/** Stub XSource returning canned pages. */
+class StubXSource implements XSource {
+  likePages: FetchPage[] = [];
+  bookmarkPages: FetchPage[] = [];
+  private likeCallIndex = 0;
+  private bookmarkCallIndex = 0;
+
+  async fetchLikes(_userId: string, _cursor?: string): Promise<FetchPage> {
+    return this.likePages[this.likeCallIndex++] ?? { items: [] };
+  }
+
+  async fetchBookmarks(_userId: string, _cursor?: string): Promise<FetchPage> {
+    return this.bookmarkPages[this.bookmarkCallIndex++] ?? { items: [] };
+  }
+}
+
+/** Fake UsersRepo tracking calls. */
+class FakeUsersRepo {
+  users = new Map<string, UserRecord>();
+  cursorUpdates: Array<{ userId: string; cursors: Record<string, string> }> = [];
+
+  async findById(userId: string): Promise<UserRecord | null> {
+    return this.users.get(userId) ?? null;
+  }
+
+  async updateCursors(
+    userId: string,
+    cursors: { lastLikeCursor?: string; lastBookmarkCursor?: string },
+  ): Promise<UserRecord> {
+    this.cursorUpdates.push({ userId, cursors: cursors as Record<string, string> });
+    const user = this.users.get(userId);
+    if (!user) throw new Error('user not found');
+    return { ...user, ...cursors };
+  }
+}
+
+/** Fake ItemsRepo tracking upserts. */
+class FakeItemsRepo {
+  upserted: Array<{ userId: string; items: TweetItem[] }> = [];
+  private nextId = 1;
+  private knownTweetIds = new Set<string>();
+
+  async upsertMany(
+    userId: string,
+    items: TweetItem[],
+  ): Promise<Array<{ id: string; isNew: boolean }>> {
+    this.upserted.push({ userId, items: [...items] });
+    return items.map((item) => {
+      const key = `${userId}:${item.tweetId}`;
+      const isNew = !this.knownTweetIds.has(key);
+      this.knownTweetIds.add(key);
+      return { id: `item-${this.nextId++}`, isNew };
+    });
+  }
+}
+
+/** Fake extract-item queue tracking added jobs. */
+class FakeExtractQueue {
+  jobs: Array<{ name: string; data: unknown }> = [];
+
+  async add(name: string, data: unknown): Promise<void> {
+    this.jobs.push({ name, data });
+  }
+}
+
+/** Fake logger collecting log calls. */
+class FakeLogger {
+  logs: Array<{ level: string; msg: string; context?: Record<string, unknown> }> = [];
+
+  info(msg: string, context?: Record<string, unknown>) {
+    this.logs.push({ level: 'info', msg, context });
+  }
+
+  warn(msg: string, context?: Record<string, unknown>) {
+    this.logs.push({ level: 'warn', msg, context });
+  }
+}
+
+function activeUser(overrides: Partial<UserRecord> = {}): UserRecord {
+  return {
+    id: 'user-1',
+    xUserId: '99999',
+    handle: 'testuser',
+    status: 'active',
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeTweet(overrides: Partial<TweetItem> = {}): TweetItem {
+  return {
+    tweetId: 'tw-1',
+    text: 'check this out',
+    authorHandle: 'author1',
+    urls: ['https://example.com/article'],
+    kind: 'like',
+    ...overrides,
+  };
+}
+
+function makeProcessor() {
+  const xSource = new StubXSource();
+  const users = new FakeUsersRepo();
+  const items = new FakeItemsRepo();
+  const extractQueue = new FakeExtractQueue();
+  const logger = new FakeLogger();
+
+  const processor = new PollXProcessor(
+    xSource,
+    extractQueue as never,
+    users as never,
+    items as never,
+    logger as never,
+  );
+
+  return { processor, xSource, users, items, extractQueue, logger };
+}
+
+describe('PollXProcessor.process', () => {
+  it('fetches likes and bookmarks, upserts items, updates cursors, enqueues extraction', async () => {
+    const { processor, xSource, users, items, extractQueue } = makeProcessor();
+    const user = activeUser();
+    users.users.set(user.id, user);
+
+    xSource.likePages = [
+      { items: [makeTweet({ tweetId: 'tw-1', kind: 'like' })], nextCursor: 'lc1' },
+      { items: [makeTweet({ tweetId: 'tw-2', kind: 'like' })] },
+    ];
+    xSource.bookmarkPages = [
+      { items: [makeTweet({ tweetId: 'tw-3', kind: 'bookmark', urls: [] })] },
+    ];
+
+    await processor.process({ data: { userId: user.id }, attemptsMade: 0 });
+
+    // Items upserted: 2 likes + 1 bookmark.
+    expect(items.upserted).toHaveLength(2);
+    expect(items.upserted[0]!.items).toHaveLength(2);
+    expect(items.upserted[1]!.items).toHaveLength(1);
+
+    // Extract jobs enqueued only for items with URLs (tw-1 and tw-2, not tw-3).
+    expect(extractQueue.jobs).toHaveLength(2);
+    expect(extractQueue.jobs[0]!.data).toEqual({ userId: user.id, itemId: 'item-1' });
+    expect(extractQueue.jobs[1]!.data).toEqual({ userId: user.id, itemId: 'item-2' });
+  });
+
+  it('skips extract-item enqueue for items without URLs', async () => {
+    const { processor, xSource, users, extractQueue } = makeProcessor();
+    const user = activeUser();
+    users.users.set(user.id, user);
+
+    xSource.likePages = [
+      { items: [makeTweet({ tweetId: 'tw-1', urls: [] })] },
+    ];
+    xSource.bookmarkPages = [{ items: [] }];
+
+    await processor.process({ data: { userId: user.id }, attemptsMade: 0 });
+
+    expect(extractQueue.jobs).toHaveLength(0);
+  });
+
+  it('updates cursors with the final pagination cursor', async () => {
+    const { processor, xSource, users } = makeProcessor();
+    const user = activeUser();
+    users.users.set(user.id, user);
+
+    xSource.likePages = [
+      { items: [makeTweet()], nextCursor: 'lc1' },
+      { items: [], nextCursor: 'lc2' },
+      { items: [] },
+    ];
+    xSource.bookmarkPages = [
+      { items: [], nextCursor: 'bc1' },
+      { items: [] },
+    ];
+
+    await processor.process({ data: { userId: user.id }, attemptsMade: 0 });
+
+    expect(users.cursorUpdates).toHaveLength(1);
+    expect(users.cursorUpdates[0]!.cursors).toEqual({
+      lastLikeCursor: 'lc2',
+      lastBookmarkCursor: 'bc1',
+    });
+  });
+
+  it('returns early without retry when user is missing', async () => {
+    const { processor, items, extractQueue } = makeProcessor();
+
+    await processor.process({ data: { userId: 'gone' }, attemptsMade: 0 });
+
+    expect(items.upserted).toHaveLength(0);
+    expect(extractQueue.jobs).toHaveLength(0);
+  });
+
+  it('returns early without retry when user status is not active', async () => {
+    const { processor, users, items } = makeProcessor();
+    const user = activeUser({ status: 'auth_expired' });
+    users.users.set(user.id, user);
+
+    await processor.process({ data: { userId: user.id }, attemptsMade: 0 });
+
+    expect(items.upserted).toHaveLength(0);
+  });
+
+  it('catches AuthExpiredError and returns without throwing', async () => {
+    const { processor, xSource, users, items } = makeProcessor();
+    const user = activeUser();
+    users.users.set(user.id, user);
+
+    xSource.fetchLikes = async () => {
+      throw new AuthExpiredError('refresh failed');
+    };
+
+    // Should NOT throw — AuthExpiredError is caught.
+    await processor.process({ data: { userId: user.id }, attemptsMade: 0 });
+
+    expect(items.upserted).toHaveLength(0);
+  });
+
+  it('lets transport errors propagate for BullMQ retry', async () => {
+    const { processor, xSource, users } = makeProcessor();
+    const user = activeUser();
+    users.users.set(user.id, user);
+
+    xSource.fetchLikes = async () => {
+      throw new Error('x api v2 request timed out');
+    };
+
+    await expect(
+      processor.process({ data: { userId: user.id }, attemptsMade: 0 }),
+    ).rejects.toThrow('x api v2 request timed out');
+  });
+
+  it('passes stored cursors into XSource calls', async () => {
+    const { processor, xSource, users } = makeProcessor();
+    const user = activeUser({
+      lastLikeCursor: 'stored-lc',
+      lastBookmarkCursor: 'stored-bc',
+    });
+    users.users.set(user.id, user);
+
+    const likeCursors: Array<string | undefined> = [];
+    const bookmarkCursors: Array<string | undefined> = [];
+
+    xSource.fetchLikes = async (_userId: string, cursor?: string) => {
+      likeCursors.push(cursor);
+      return { items: [] };
+    };
+    xSource.fetchBookmarks = async (_userId: string, cursor?: string) => {
+      bookmarkCursors.push(cursor);
+      return { items: [] };
+    };
+
+    await processor.process({ data: { userId: user.id }, attemptsMade: 0 });
+
+    expect(likeCursors[0]).toBe('stored-lc');
+    expect(bookmarkCursors[0]).toBe('stored-bc');
+  });
+
+  it('only enqueues extract-item for NEW items, not duplicates', async () => {
+    const { processor, xSource, users, items, extractQueue } = makeProcessor();
+    const user = activeUser();
+    users.users.set(user.id, user);
+
+    // Pre-mark tw-1 as known.
+    items.knownTweetIds.add(`${user.id}:tw-1`);
+
+    xSource.likePages = [
+      {
+        items: [
+          makeTweet({ tweetId: 'tw-1', urls: ['https://a.com'] }),
+          makeTweet({ tweetId: 'tw-2', urls: ['https://b.com'] }),
+        ],
+      },
+    ];
+    xSource.bookmarkPages = [{ items: [] }];
+
+    await processor.process({ data: { userId: user.id }, attemptsMade: 0 });
+
+    // Only tw-2 is new, so only one extract job.
+    expect(extractQueue.jobs).toHaveLength(1);
+    expect((extractQueue.jobs[0]!.data as { itemId: string }).itemId).toBe('item-2');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bun test src/workers/poll-x.processor.test.ts`
+Expected: Failure — module `./poll-x.processor` not found.
+
+- [ ] **Step 3: Implement PollXProcessor**
+
+Create `src/workers/poll-x.processor.ts`:
+
+```ts
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { AuthExpiredError } from '../auth/auth.service';
+import type { FetchPage, TweetItem, XSource } from '../ingestion/x-source.port';
+import { X_SOURCE } from '../ingestion/ingestion.module';
+import { EXTRACT_ITEM_QUEUE } from '../queue/queue.tokens';
+import { UsersRepo } from '../users/users.repo';
+import { ItemsRepo } from './items.repo';
+
+/** Minimal job shape — no BullMQ types in the public interface. */
+export interface PollXJob {
+  data: { userId: string };
+  attemptsMade: number;
+}
+
+@Injectable()
+export class PollXProcessor {
+  private readonly logger = new Logger(PollXProcessor.name);
+
+  constructor(
+    @Inject(X_SOURCE) private readonly xSource: XSource,
+    @Inject(EXTRACT_ITEM_QUEUE) private readonly extractQueue: { add(name: string, data: unknown): Promise<unknown> },
+    private readonly users: UsersRepo,
+    private readonly items: ItemsRepo,
+  ) {}
+
+  async process(job: PollXJob): Promise<void> {
+    const { userId } = job.data;
+    const start = Date.now();
+
+    const user = await this.users.findById(userId);
+    if (!user || user.status !== 'active') {
+      this.logger.warn(`skipping poll: user ${userId} is ${user?.status ?? 'missing'}`);
+      return;
+    }
+
+    let likeItems: TweetItem[];
+    let lastLikeCursor: string | undefined;
+    let bookmarkItems: TweetItem[];
+    let lastBookmarkCursor: string | undefined;
+
+    try {
+      ({ items: likeItems, cursor: lastLikeCursor } = await this.fetchAll(
+        (cursor) => this.xSource.fetchLikes(userId, cursor),
+        user.lastLikeCursor,
+      ));
+      ({ items: bookmarkItems, cursor: lastBookmarkCursor } = await this.fetchAll(
+        (cursor) => this.xSource.fetchBookmarks(userId, cursor),
+        user.lastBookmarkCursor,
+      ));
+    } catch (err) {
+      if (err instanceof AuthExpiredError) {
+        this.logger.warn(`auth expired for user ${userId}, stopping poll`);
+        return;
+      }
+      throw err;
+    }
+
+    const likeResults = await this.items.upsertMany(userId, likeItems);
+    const bookmarkResults = await this.items.upsertMany(userId, bookmarkItems);
+    const allResults = [...likeResults, ...bookmarkResults];
+    const allItems = [...likeItems, ...bookmarkItems];
+
+    let extractJobsEnqueued = 0;
+    for (let i = 0; i < allResults.length; i++) {
+      const result = allResults[i]!;
+      const item = allItems[i]!;
+      if (result.isNew && item.urls.length > 0) {
+        await this.extractQueue.add('extract-item', {
+          userId,
+          itemId: result.id,
+        });
+        extractJobsEnqueued++;
+      }
+    }
+
+    const cursors: { lastLikeCursor?: string; lastBookmarkCursor?: string } = {};
+    if (lastLikeCursor !== undefined) cursors.lastLikeCursor = lastLikeCursor;
+    if (lastBookmarkCursor !== undefined) cursors.lastBookmarkCursor = lastBookmarkCursor;
+    if (Object.keys(cursors).length > 0) {
+      await this.users.updateCursors(userId, cursors);
+    }
+
+    const durationMs = Date.now() - start;
+    this.logger.info('poll complete', {
+      userId,
+      attempt: job.attemptsMade,
+      durationMs,
+      newLikes: likeResults.filter((r) => r.isNew).length,
+      newBookmarks: bookmarkResults.filter((r) => r.isNew).length,
+      extractJobsEnqueued,
+    });
+  }
+
+  /**
+   * Walk all pages from a fetch function until `nextCursor` is absent.
+   * Returns all collected items and the last cursor seen (for persisting).
+   */
+  private async fetchAll(
+    fetchPage: (cursor?: string) => Promise<FetchPage>,
+    initialCursor?: string,
+  ): Promise<{ items: TweetItem[]; cursor?: string }> {
+    const collected: TweetItem[] = [];
+    let cursor: string | undefined = initialCursor;
+    let lastCursor: string | undefined;
+
+    // biome-ignore lint/correctness/noConstantCondition: pagination loop
+    while (true) {
+      const page = await fetchPage(cursor);
+      collected.push(...page.items);
+      if (page.nextCursor) {
+        lastCursor = page.nextCursor;
+        cursor = page.nextCursor;
+      } else {
+        break;
+      }
+    }
+    return { items: collected, cursor: lastCursor };
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `bun test src/workers/poll-x.processor.test.ts`
+Expected: All tests pass.
+
+- [ ] **Step 5: Run typecheck**
+
+Run: `bunx tsc --noEmit`
+Expected: Clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/workers/poll-x.processor.ts src/workers/poll-x.processor.test.ts
+git commit -m "feat(workers): add PollXProcessor for poll-x queue"
+```
+
+---
+
+### Task 5: Create WorkersModule
+
+**Files:**
+- Create: `src/workers/workers.module.ts`
+- Modify: `src/app.module.ts`
+
+- [ ] **Step 1: Create WorkersModule**
+
+Create `src/workers/workers.module.ts`:
+
+```ts
+import {
+  type DynamicModule,
+  Inject,
+  Logger,
+  Module,
+  type OnModuleDestroy,
+  type OnModuleInit,
+} from '@nestjs/common';
+import { Worker } from 'bullmq';
+import type { Redis } from 'ioredis';
+import type { Env } from '../config/env';
+import {
+  EXTRACT_ITEM_QUEUE,
+  POLL_X_QUEUE_NAME,
+  REDIS_CLIENT,
+} from '../queue/queue.tokens';
+import { PollXProcessor } from './poll-x.processor';
+import { ItemsRepo } from './items.repo';
+
+/**
+ * Owns BullMQ `Worker` instances for all processor queues.
+ *
+ * This milestone (#7) registers only the `poll-x` worker. Future
+ * milestones (#8 `extract-item`, #11 `build-digest`) add their
+ * workers here.
+ *
+ * The module creates the `Worker` in `onModuleInit` and closes it
+ * gracefully in `onModuleDestroy`, ensuring in-flight jobs finish
+ * before the Redis connection is reclaimed by `QueueModule`.
+ */
+@Module({})
+export class WorkersModule implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(WorkersModule.name);
+  private pollXWorker?: Worker;
+
+  constructor(
+    @Inject(REDIS_CLIENT) private readonly redis: Redis,
+    private readonly pollXProcessor: PollXProcessor,
+  ) {}
+
+  static forRoot(env: Env): DynamicModule {
+    return {
+      module: WorkersModule,
+      providers: [
+        ItemsRepo,
+        PollXProcessor,
+        {
+          provide: 'POLL_X_CONCURRENCY',
+          useValue: env.POLL_X_CONCURRENCY,
+        },
+      ],
+      exports: [],
+    };
+  }
+
+  onModuleInit() {
+    this.pollXWorker = new Worker(
+      POLL_X_QUEUE_NAME,
+      async (job) => this.pollXProcessor.process(job),
+      {
+        connection: this.redis,
+        concurrency: 5,
+      },
+    );
+    this.logger.log(`poll-x worker started (concurrency: 5)`);
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    if (this.pollXWorker) {
+      try {
+        await this.pollXWorker.close();
+        this.logger.log('poll-x worker closed');
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.logger.warn(`failed to close poll-x worker: ${message}`);
+      }
+    }
+  }
+}
+```
+
+Wait — there's a problem. The concurrency should come from the `forRoot(env)` call, but the module instance that runs `onModuleInit` can't easily access the value passed to the static method. Let me restructure to use a provider for concurrency.
+
+```ts
+import {
+  type DynamicModule,
+  Inject,
+  Logger,
+  Module,
+  type OnModuleDestroy,
+  type OnModuleInit,
+} from '@nestjs/common';
+import { Worker } from 'bullmq';
+import type { Redis } from 'ioredis';
+import {
+  POLL_X_QUEUE_NAME,
+  REDIS_CLIENT,
+} from '../queue/queue.tokens';
+import type { Env } from '../config/env';
+import { PollXProcessor } from './poll-x.processor';
+import { ItemsRepo } from './items.repo';
+
+const POLL_X_CONCURRENCY = 'POLL_X_CONCURRENCY';
+
+@Module({})
+export class WorkersModule implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(WorkersModule.name);
+  private pollXWorker?: Worker;
+
+  constructor(
+    @Inject(REDIS_CLIENT) private readonly redis: Redis,
+    @Inject(POLL_X_CONCURRENCY) private readonly concurrency: number,
+    private readonly pollXProcessor: PollXProcessor,
+  ) {}
+
+  static forRoot(env: Env): DynamicModule {
+    return {
+      module: WorkersModule,
+      providers: [
+        ItemsRepo,
+        PollXProcessor,
+        { provide: POLL_X_CONCURRENCY, useValue: env.POLL_X_CONCURRENCY },
+      ],
+    };
+  }
+
+  onModuleInit() {
+    this.pollXWorker = new Worker(
+      POLL_X_QUEUE_NAME,
+      async (job) => this.pollXProcessor.process(job),
+      {
+        connection: this.redis,
+        concurrency: this.concurrency,
+      },
+    );
+    this.logger.log(`poll-x worker started (concurrency: ${this.concurrency})`);
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    if (this.pollXWorker) {
+      try {
+        await this.pollXWorker.close();
+        this.logger.log('poll-x worker closed');
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.logger.warn(`failed to close poll-x worker: ${message}`);
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Register WorkersModule in AppModule**
+
+In `src/app.module.ts`, add the import:
+
+```ts
+import { WorkersModule } from './workers/workers.module';
+```
+
+Add `WorkersModule.forRoot(env)` to the imports array after `IngestionModule.forRoot(env)`:
+
+```ts
+        IngestionModule.forRoot(env),
+        WorkersModule.forRoot(env),
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `bunx tsc --noEmit`
+Expected: Clean.
+
+- [ ] **Step 4: Run all tests**
+
+Run: `bun test`
+Expected: All tests pass.
+
+- [ ] **Step 5: Run lint**
+
+Run: `bunx biome lint .`
+Expected: Clean (or fix any issues).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/workers/workers.module.ts src/app.module.ts
+git commit -m "feat(workers): add WorkersModule with poll-x Worker lifecycle"
+```
+
+---
+
+### Task 6: Version bump and final verification
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Bump version**
+
+In `package.json`, change `"version": "0.6.0"` to `"version": "0.7.0"`.
+
+- [ ] **Step 2: Run full verification**
+
+```bash
+bun test && bunx tsc --noEmit && bunx biome lint .
+```
+
+Expected: All green.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json
+git commit -m "chore: bump version to 0.7.0"
+```

--- a/docs/specs/plans/2026-04-13-poll-x-processor.md
+++ b/docs/specs/plans/2026-04-13-poll-x-processor.md
@@ -588,13 +588,11 @@ function toItemRecord(doc: Record<string, unknown> & { $id: string }): ItemRecor
 }
 ```
 
-Wait — the `findByUserAndTweetId` approach is problematic. The 409 conflict handler needs to find the existing document's ID. Let me rethink.
+The initial approach above lacked `listDocuments` for conflict resolution.
+The final implementation uses `ID.unique()` + compound unique index +
+`listDocuments` query on 409 to retrieve the existing document ID.
 
-Actually, I'll take a simpler approach: track a local `Map<string, string>` inside `upsertMany` for items we've already created in this batch, and for 409 conflicts, use `listDocuments` with a query. Let me add `listDocuments` to the structural interface.
-
-Let me rewrite this properly.
-
-Create `src/workers/items.repo.ts`:
+Create `src/workers/items.repo.ts` (final version):
 
 ```ts
 import { Injectable } from '@nestjs/common';
@@ -1346,7 +1344,8 @@ export class WorkersModule implements OnModuleInit, OnModuleDestroy {
 }
 ```
 
-Wait — there's a problem. The concurrency should come from the `forRoot(env)` call, but the module instance that runs `onModuleInit` can't easily access the value passed to the static method. Let me restructure to use a provider for concurrency.
+The concurrency value from `forRoot(env)` is passed to the module instance
+via a DI provider token, allowing `onModuleInit` to access it.
 
 ```ts
 import {

--- a/docs/specs/poll-x-processor.md
+++ b/docs/specs/poll-x-processor.md
@@ -1,0 +1,199 @@
+---
+title: "poll-x processor + WorkersModule"
+type: spec
+tags: [workers, poll-x, bullmq, ingestion, items, cursor, queue, hexagonal]
+created: 2026-04-13
+updated: 2026-04-13
+issue: 7
+---
+
+## Behavior
+
+This milestone adds the first BullMQ worker to the system. A new
+`WorkersModule` creates a `Worker` instance that consumes the `poll-x`
+queue. The processing logic lives in `PollXProcessor`, a plain
+injectable class whose public surface carries no BullMQ types.
+
+A new `ItemsRepo` adapter handles persistence for the `items` Appwrite
+collection, and `UsersRepo` gains an `updateCursors` method for
+persisting pagination state after a successful poll.
+
+Scope:
+
+1. **`PollXProcessor`** (`src/workers/poll-x.processor.ts`) — the
+   processing logic for the `poll-x` queue. Injectable class with a
+   single public method:
+
+   ```ts
+   async process(job: { data: { userId: string }; attemptsMade: number }): Promise<void>
+   ```
+
+   Steps:
+   a. Load user via `UsersRepo.findById(userId)`. If missing or
+      `status !== 'active'`, log at warn and return (no retry — the
+      user was deleted or paused between scheduling and execution).
+   b. Fetch likes: call `XSource.fetchLikes(userId, user.lastLikeCursor)`,
+      follow `nextCursor` until exhausted. Collect all `TweetItem[]`.
+   c. Fetch bookmarks: call `XSource.fetchBookmarks(userId, user.lastBookmarkCursor)`,
+      follow `nextCursor` until exhausted. Collect all `TweetItem[]`.
+   d. Upsert all collected items via `ItemsRepo.upsertMany(userId, items)`.
+      Dedup on `(userId, xTweetId)` using deterministic document IDs.
+      Returns `{ id: string; isNew: boolean }[]` so the processor knows
+      which items are newly created.
+   e. Enqueue `extract-item` jobs: for each new item with non-empty
+      `urls[]`, add a job to `EXTRACT_ITEM_QUEUE` with payload
+      `{ userId, itemId }`.
+   f. Update cursors: call `UsersRepo.updateCursors(userId, { lastLikeCursor, lastBookmarkCursor })`
+      with the final cursor from each pagination run. Only called after
+      items are persisted — cursors advance only on successful upsert.
+   g. Log completion: `userId`, `attempt`, `durationMs`, `newLikes`,
+      `newBookmarks`, `extractJobsEnqueued`.
+
+   Error handling:
+   - **Auth failure**: if `XSource` throws `AuthExpiredError` (exported
+     from `src/auth/auth.service.ts`), catch it and return without
+     retrying. `AuthService.getValidAccessToken` — called internally
+     by `XApiV2Source` — already calls `failAuth(userId)` before
+     throwing, which marks the user `auth_expired` and removes their
+     schedulers. The processor does not need to call `failAuth` itself.
+   - **Transport errors** (X API timeouts, 5xx): let throw. BullMQ
+     retries with the configured backoff.
+   - **Appwrite errors** (item upsert, cursor update): let throw.
+     BullMQ retries handle transient Appwrite outages.
+
+2. **`ItemsRepo`** (`src/workers/items.repo.ts`) — adapter for the
+   `items` Appwrite collection. Follows the same patterns as `TokensRepo`
+   and `UsersRepo`: structural typing for the Appwrite SDK, plain shapes
+   returned, `null` on 404.
+
+   ```ts
+   interface ItemRecord {
+     id: string;
+     userId: string;
+     xTweetId: string;
+     kind: TweetKind;
+     text: string;
+     authorHandle: string;
+     urls: string[];
+     fetchedAt: string;
+     enriched: boolean;
+   }
+   ```
+
+   Public methods:
+
+   ```ts
+   async upsertMany(userId: string, items: TweetItem[]): Promise<{ id: string; isNew: boolean }[]>
+   ```
+   - Document ID: deterministic `${userId}:${xTweetId}` — avoids
+     TOCTOU races (same pattern as `TokensRepo` using `userId` as
+     document ID).
+   - For each item: try create; on 409 conflict, mark `isNew: false`.
+   - Sets `fetchedAt` to current ISO timestamp on create.
+   - Sets `enriched` to `false` on create.
+
+   ```ts
+   async findByUserAndTweetId(userId: string, xTweetId: string): Promise<ItemRecord | null>
+   ```
+
+3. **`UsersRepo.updateCursors`** (`src/users/users.repo.ts`) — new
+   method on the existing repo:
+
+   ```ts
+   async updateCursors(userId: string, cursors: {
+     lastLikeCursor?: string;
+     lastBookmarkCursor?: string;
+   }): Promise<UserRecord>
+   ```
+   - Updates only the provided cursor fields (partial patch).
+   - Throws if user not found (cursor update on a missing user is a
+     bug, unlike `ScheduleService` where a missing user is a no-op).
+
+4. **`WorkersModule`** (`src/workers/workers.module.ts`) — owns the
+   BullMQ `Worker` lifecycle.
+
+   ```ts
+   static forRoot(env: Env): DynamicModule
+   ```
+
+   - Creates `ItemsRepo` provider (injecting `AppwriteService` and
+     the items collection ID from env/constants).
+   - Creates `PollXProcessor` provider (injecting `X_SOURCE`,
+     `EXTRACT_ITEM_QUEUE`, `UsersRepo`, `ItemsRepo`, `AuthService`).
+   - In `onModuleInit`: creates a BullMQ `Worker` on queue name
+     `'poll-x'`, wired to `PollXProcessor.process`. Configuration:
+     - `connection`: shared `REDIS_CLIENT`
+     - `concurrency`: `env.POLL_X_CONCURRENCY` (default 5)
+   - In `onModuleDestroy`: calls `worker.close()` for graceful
+     shutdown (waits for in-flight jobs to finish).
+   - Retry config set as default job options on the Worker:
+     `attempts: 5`, `backoff: { type: 'exponential', delay: 30_000 }`,
+     with a cap at 10 minutes.
+
+   Registered in `AppModule.forRoot()` after `IngestionModule`:
+   ```ts
+   imports: [
+     // ... existing modules ...
+     IngestionModule.forRoot(env),
+     WorkersModule.forRoot(env),  // NEW
+   ]
+   ```
+
+5. **`AuthService` integration** — the processor catches
+   `AuthExpiredError` thrown by `XSource` (which internally calls
+   `AuthService.getValidAccessToken`). `getValidAccessToken` already
+   calls `failAuth` before throwing, so by the time the processor
+   sees the error the user is already marked `auth_expired` and their
+   schedulers are removed. The processor just catches and returns
+   (no retry). No changes to `AuthService` are needed.
+
+## Constraints
+
+- **Hexagonal containment**: BullMQ `Worker` and `Job` types stay
+  inside `src/workers/workers.module.ts`. `PollXProcessor`'s public
+  method signature uses a plain object type for the job argument, not
+  `Job<PollXJob>`.
+- **Cursor update ordering**: cursors advance only AFTER items are
+  successfully persisted. If item upsert fails and the job retries,
+  the same items will be fetched again (idempotent via dedup) rather
+  than being silently skipped.
+- **No pagination limit on first poll**: a new user's first poll may
+  fetch many pages. This is acceptable because the work runs in a
+  BullMQ processor (not on the request path) and X API rate limits
+  provide natural backpressure.
+- **Deterministic document IDs for items**: `${userId}:${xTweetId}`
+  ensures concurrent retries or overlapping polls cannot create
+  duplicate items.
+- **Extract-item enqueuing is best-effort per job**: if the processor
+  crashes after upserting items but before enqueuing extract-item jobs,
+  the retry will re-upsert (no-op due to dedup) and enqueue. Items
+  that were already enqueued on the previous attempt will produce
+  duplicate extract-item jobs — the extract-item processor (milestone
+  #8) must be idempotent.
+- **Retry config lives on the Worker**, not on individual `queue.add()`
+  calls. The `poll-x` Worker defaults: 5 attempts, exponential backoff
+  base 30s, max 10m (per `docs/jobs.md`).
+- **Version**: bump `package.json` from `0.6.0` → `0.7.0`.
+
+## Acceptance Criteria
+
+- [ ] `WorkersModule` exists with `PollXProcessor` consuming the
+      `poll-x` queue.
+- [ ] Processor refreshes tokens (via XSource → AuthService internally),
+      calls `XSource.fetchLikes` and `XSource.fetchBookmarks`, upserts
+      `items` (deduped on `xTweetId`), updates user cursors, enqueues
+      `extract-item` for items with non-empty `urls`.
+- [ ] `AuthExpiredError` from XSource is caught; job returns without
+      retrying (user is already marked `auth_expired` by AuthService).
+- [ ] Retries per `docs/jobs.md` (5 attempts, exponential 30s base,
+      10m cap).
+- [ ] Logs `userId`, `attempt`, `durationMs`, `newItems`.
+- [ ] E2E test using a stub `XSource` injected via the Nest test
+      module verifies: items created, cursors updated, extract-item
+      jobs enqueued for items with URLs, no extract jobs for items
+      without URLs.
+- [ ] `UsersRepo.updateCursors` method added and unit tested.
+- [ ] `ItemsRepo.upsertMany` deduplicates on `(userId, xTweetId)`.
+- [ ] `package.json` version bumped `0.6.0` → `0.7.0`.
+- [ ] `bun test`, `bunx tsc --noEmit`, and `bunx biome lint .` are
+      green.

--- a/docs/specs/poll-x-processor.md
+++ b/docs/specs/poll-x-processor.md
@@ -37,7 +37,8 @@ Scope:
    c. Fetch bookmarks: call `XSource.fetchBookmarks(userId, user.lastBookmarkCursor)`,
       follow `nextCursor` until exhausted. Collect all `TweetItem[]`.
    d. Upsert all collected items via `ItemsRepo.upsertMany(userId, items)`.
-      Dedup on `(userId, xTweetId)` using deterministic document IDs.
+      Dedup on `(userId, xTweetId)` using `ID.unique()` document IDs with
+      a compound unique index; 409 conflicts indicate duplicates.
       Returns `{ id: string; isNew: boolean }[]` so the processor knows
       which items are newly created.
    e. Enqueue `extract-item` jobs: for each new item with non-empty
@@ -47,7 +48,7 @@ Scope:
       with the final cursor from each pagination run. Only called after
       items are persisted — cursors advance only on successful upsert.
    g. Log completion: `userId`, `attempt`, `durationMs`, `newLikes`,
-      `newBookmarks`, `extractJobsEnqueued`.
+      `newBookmarks`, `newItems`, `extractJobsEnqueued`.
 
    Error handling:
    - **Auth failure**: if `XSource` throws `AuthExpiredError` (exported
@@ -85,9 +86,9 @@ Scope:
    ```ts
    async upsertMany(userId: string, items: TweetItem[]): Promise<{ id: string; isNew: boolean }[]>
    ```
-   - Document ID: deterministic `${userId}:${xTweetId}` — avoids
-     TOCTOU races (same pattern as `TokensRepo` using `userId` as
-     document ID).
+   - Document ID: `ID.unique()` with a compound unique index on
+     `(userId, xTweetId)`. On 409 conflict (or `document_already_exists`
+     type), query back the existing document and mark `isNew: false`.
    - For each item: try create; on 409 conflict, mark `isNew: false`.
    - Sets `fetchedAt` to current ISO timestamp on create.
    - Sets `enriched` to `false` on create.
@@ -126,9 +127,9 @@ Scope:
      - `concurrency`: `env.POLL_X_CONCURRENCY` (default 5)
    - In `onModuleDestroy`: calls `worker.close()` for graceful
      shutdown (waits for in-flight jobs to finish).
-   - Retry config set as default job options on the Worker:
-     `attempts: 5`, `backoff: { type: 'exponential', delay: 30_000 }`,
-     with a cap at 10 minutes.
+   - Retry/backoff configured via job options on `queue.add()` or
+     Queue `defaultJobOptions`. `poll-x` Worker: 5 attempts, exponential
+     backoff base 30s, max 10m (per `docs/jobs.md`).
 
    Registered in `AppModule.forRoot()` after `IngestionModule`:
    ```ts
@@ -161,18 +162,18 @@ Scope:
   fetch many pages. This is acceptable because the work runs in a
   BullMQ processor (not on the request path) and X API rate limits
   provide natural backpressure.
-- **Deterministic document IDs for items**: `${userId}:${xTweetId}`
-  ensures concurrent retries or overlapping polls cannot create
-  duplicate items.
+- **Compound unique index for items**: the `(userId, xTweetId)` unique
+  index combined with 409 conflict handling ensures concurrent retries
+  or overlapping polls cannot create duplicate items.
 - **Extract-item enqueuing is best-effort per job**: if the processor
   crashes after upserting items but before enqueuing extract-item jobs,
   the retry will re-upsert (no-op due to dedup) and enqueue. Items
   that were already enqueued on the previous attempt will produce
   duplicate extract-item jobs — the extract-item processor (milestone
   #8) must be idempotent.
-- **Retry config lives on the Worker**, not on individual `queue.add()`
-  calls. The `poll-x` Worker defaults: 5 attempts, exponential backoff
-  base 30s, max 10m (per `docs/jobs.md`).
+- **Retry config** set via job options on `queue.add()` or Queue
+  `defaultJobOptions`. The `poll-x` defaults: 5 attempts, exponential
+  backoff base 30s, max 10m (per `docs/jobs.md`).
 - **Version**: bump `package.json` from `0.6.0` → `0.7.0`.
 
 ## Acceptance Criteria
@@ -187,7 +188,8 @@ Scope:
       retrying (user is already marked `auth_expired` by AuthService).
 - [ ] Retries per `docs/jobs.md` (5 attempts, exponential 30s base,
       10m cap).
-- [ ] Logs `userId`, `attempt`, `durationMs`, `newItems`.
+- [ ] Logs `userId`, `attempt`, `durationMs`, `newLikes`, `newBookmarks`,
+      `newItems`, `extractJobsEnqueued`.
 - [ ] E2E test using a stub `XSource` injected via the Nest test
       module verifies: items created, cursors updated, extract-item
       jobs enqueued for items with URLs, no extract jobs for items

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x-reporter",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "description": "Per-user X likes/bookmarks digest service (Bun + NestJS)",

--- a/src/app.module.test.ts
+++ b/src/app.module.test.ts
@@ -6,6 +6,7 @@ import { SESSION_COOKIE_NAME } from './auth/auth.controller';
 import { signCookieValue } from './auth/cookies';
 import { REDIS_HEALTH, type RedisHealthPort } from './queue/queue.tokens';
 import { ScheduleService } from './schedule/schedule.service';
+import { WorkersLifecycle } from './workers/workers.module';
 
 const TEST_SESSION_SECRET = 'a-test-session-secret-at-least-32-chars-long';
 const TEST_USER_ID = 'u_e2e_test_abc';
@@ -173,6 +174,10 @@ describe('AppModule (e2e-lite)', () => {
       .useValue(fakeSchedule)
       .overrideProvider(REDIS_HEALTH)
       .useValue(fakeRedisHealth)
+      // WorkersLifecycle creates BullMQ Workers on init that connect to
+      // Redis. Override with a no-op so the e2e-lite test works offline.
+      .overrideProvider(WorkersLifecycle)
+      .useValue({ onModuleInit() {}, async onModuleDestroy() {} })
       .compile();
 
     app = moduleRef.createNestApplication();

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { QueueModule } from './queue/queue.module';
 import { ScheduleModule } from './schedule/schedule.module';
 import { UsersModule } from './users/users.module';
 import { UsersRepoModule } from './users/users-repo.module';
+import { WorkersModule } from './workers/workers.module';
 
 /**
  * The application root module.
@@ -64,6 +65,7 @@ export class AppModule {
         AuthModule.forRoot(env),
         UsersModule.forRoot(env),
         IngestionModule.forRoot(env),
+        WorkersModule.forRoot(env),
       ],
     };
   }

--- a/src/ingestion/ingestion.module.ts
+++ b/src/ingestion/ingestion.module.ts
@@ -67,6 +67,10 @@ export class IngestionModule {
 
     return {
       module: IngestionModule,
+      // `global: true` so `WorkersModule` (milestone #7) can inject
+      // `X_SOURCE` without re-importing IngestionModule. Same pattern
+      // as `AuthModule` and `QueueModule`.
+      global: true,
       // No `imports` here: `AuthService` and `UsersRepo` come from the
       // global `AuthModule` registered once by `AppModule`. See the
       // module-level docblock above for why.

--- a/src/users/users.repo.test.ts
+++ b/src/users/users.repo.test.ts
@@ -441,3 +441,56 @@ describe('UsersRepo.updateCadence', () => {
     await expect(repo.updateCadence(u.id, {})).rejects.toThrow();
   });
 });
+
+describe('UsersRepo.updateCursors', () => {
+  it('writes lastLikeCursor and returns the updated record', async () => {
+    const { repo } = makeRepo();
+    const u = await repo.upsertByXUserId({ xUserId: '12345', handle: 'h' });
+    const updated = await repo.updateCursors(u.id, { lastLikeCursor: 'cursor-abc' });
+    expect(updated.id).toBe(u.id);
+    expect(updated.lastLikeCursor).toBe('cursor-abc');
+    expect(updated.lastBookmarkCursor).toBeUndefined();
+  });
+
+  it('writes lastBookmarkCursor and returns the updated record', async () => {
+    const { repo } = makeRepo();
+    const u = await repo.upsertByXUserId({ xUserId: '12345', handle: 'h' });
+    const updated = await repo.updateCursors(u.id, { lastBookmarkCursor: 'cursor-xyz' });
+    expect(updated.lastBookmarkCursor).toBe('cursor-xyz');
+  });
+
+  it('writes both cursors when both are supplied', async () => {
+    const { repo } = makeRepo();
+    const u = await repo.upsertByXUserId({ xUserId: '12345', handle: 'h' });
+    const updated = await repo.updateCursors(u.id, {
+      lastLikeCursor: 'lc',
+      lastBookmarkCursor: 'bc',
+    });
+    expect(updated.lastLikeCursor).toBe('lc');
+    expect(updated.lastBookmarkCursor).toBe('bc');
+  });
+
+  it('leaves an unspecified cursor untouched on a partial patch', async () => {
+    const { repo, db } = makeRepo();
+    const u = await repo.upsertByXUserId({ xUserId: '12345', handle: 'h' });
+    await repo.updateCursors(u.id, { lastLikeCursor: 'lc', lastBookmarkCursor: 'bc' });
+    const after = await repo.updateCursors(u.id, { lastLikeCursor: 'lc2' });
+    expect(after.lastLikeCursor).toBe('lc2');
+    expect(after.lastBookmarkCursor).toBe('bc');
+    const stored = db.docs.get(u.id);
+    expect(stored?.lastBookmarkCursor).toBe('bc');
+  });
+
+  it('throws when the user does not exist', async () => {
+    const { repo } = makeRepo();
+    await expect(
+      repo.updateCursors('does-not-exist', { lastLikeCursor: 'x' }),
+    ).rejects.toThrow();
+  });
+
+  it('throws on an empty patch', async () => {
+    const { repo } = makeRepo();
+    const u = await repo.upsertByXUserId({ xUserId: '12345', handle: 'h' });
+    await expect(repo.updateCursors(u.id, {})).rejects.toThrow();
+  });
+});

--- a/src/users/users.repo.test.ts
+++ b/src/users/users.repo.test.ts
@@ -346,6 +346,28 @@ describe('UsersRepo.findById', () => {
     stored.digestIntervalMin = 14;
     await expect(repo.findById(created.id)).rejects.toThrow(/out-of-range/);
   });
+
+  it('surfaces stored cursor values when present on the row', async () => {
+    const { repo, db } = makeRepo();
+    const created = await repo.upsertByXUserId({ xUserId: '12345', handle: 'h' });
+    const stored = db.docs.get(created.id);
+    if (!stored) throw new Error('seeded row missing');
+    stored.lastLikeCursor = 'abc123';
+    stored.lastBookmarkCursor = 'def456';
+    const found = await repo.findById(created.id);
+    expect(found).not.toBeNull();
+    expect((found as UserRecord).lastLikeCursor).toBe('abc123');
+    expect((found as UserRecord).lastBookmarkCursor).toBe('def456');
+  });
+
+  it('leaves cursors undefined when the row has never been polled', async () => {
+    const { repo } = makeRepo();
+    const created = await repo.upsertByXUserId({ xUserId: '12345', handle: 'h' });
+    const found = await repo.findById(created.id);
+    expect(found).not.toBeNull();
+    expect((found as UserRecord).lastLikeCursor).toBeUndefined();
+    expect((found as UserRecord).lastBookmarkCursor).toBeUndefined();
+  });
 });
 
 describe('UsersRepo.updateCadence', () => {

--- a/src/users/users.repo.ts
+++ b/src/users/users.repo.ts
@@ -55,6 +55,11 @@ export interface UpdateCadenceInput {
   digestIntervalMin?: number;
 }
 
+export interface UpdateCursorsInput {
+  lastLikeCursor?: string;
+  lastBookmarkCursor?: string;
+}
+
 /**
  * Structural type capturing only the slice of `appwrite.databases` that
  * `UsersRepo` actually uses. Declared here so the in-memory test fake can
@@ -221,6 +226,34 @@ export class UsersRepo {
       if (isNotFound(err)) return null;
       throw err;
     }
+  }
+
+  /**
+   * Update one or both pagination cursors. Called by the poll-x processor
+   * after items are persisted. Throws if the user does not exist (a cursor
+   * update on a missing user is a bug, not a race condition).
+   */
+  async updateCursors(
+    userId: string,
+    patch: UpdateCursorsInput,
+  ): Promise<UserRecord> {
+    const data: Record<string, unknown> = {};
+    if (patch.lastLikeCursor !== undefined) {
+      data.lastLikeCursor = patch.lastLikeCursor;
+    }
+    if (patch.lastBookmarkCursor !== undefined) {
+      data.lastBookmarkCursor = patch.lastBookmarkCursor;
+    }
+    if (Object.keys(data).length === 0) {
+      throw new Error('updateCursors called with empty patch');
+    }
+    const updated = await this.db.updateDocument({
+      databaseId: this.databaseId,
+      collectionId: COLLECTION_ID,
+      documentId: userId,
+      data,
+    });
+    return toUserRecord(updated);
   }
 
   /**

--- a/src/users/users.repo.ts
+++ b/src/users/users.repo.ts
@@ -37,6 +37,10 @@ export interface UserRecord {
    */
   pollIntervalMin?: number;
   digestIntervalMin?: number;
+  /** Opaque X pagination cursor for likes. Set by poll-x processor. */
+  lastLikeCursor?: string;
+  /** Opaque X pagination cursor for bookmarks. Set by poll-x processor. */
+  lastBookmarkCursor?: string;
 }
 
 /**
@@ -301,6 +305,8 @@ function toUserRecord(doc: Record<string, unknown> & { $id: string }): UserRecor
   // into the controller's response.
   const pollIntervalMin = optionalIntegerField(doc, 'pollIntervalMin');
   const digestIntervalMin = optionalIntegerField(doc, 'digestIntervalMin');
+  const lastLikeCursor = optionalStringField(doc, 'lastLikeCursor');
+  const lastBookmarkCursor = optionalStringField(doc, 'lastBookmarkCursor');
   return {
     id: doc.$id,
     xUserId,
@@ -309,6 +315,8 @@ function toUserRecord(doc: Record<string, unknown> & { $id: string }): UserRecor
     createdAt,
     ...(pollIntervalMin !== undefined ? { pollIntervalMin } : {}),
     ...(digestIntervalMin !== undefined ? { digestIntervalMin } : {}),
+    ...(lastLikeCursor !== undefined ? { lastLikeCursor } : {}),
+    ...(lastBookmarkCursor !== undefined ? { lastBookmarkCursor } : {}),
   };
 }
 
@@ -325,6 +333,18 @@ const CADENCE_MINIMUMS: Record<string, number> = {
   pollIntervalMin: 5,
   digestIntervalMin: 15,
 };
+
+function optionalStringField(
+  doc: Record<string, unknown> & { $id: string },
+  key: string,
+): string | undefined {
+  const value = doc[key];
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== 'string') {
+    throw new Error(`users row ${doc.$id} has non-string ${key}: ${String(value)}`);
+  }
+  return value;
+}
 
 function optionalIntegerField(
   doc: Record<string, unknown> & { $id: string },

--- a/src/workers/items.repo.test.ts
+++ b/src/workers/items.repo.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'bun:test';
+import { ItemsRepo } from './items.repo';
+
+/**
+ * In-memory fake of the Appwrite databases slice that `ItemsRepo` uses.
+ * Mirrors the compound unique index `(userId, xTweetId)` from the real
+ * schema by checking for duplicates on create.
+ */
+class FakeDatabases {
+  readonly docs = new Map<string, Record<string, unknown> & { $id: string }>();
+  private nextId = 1;
+
+  async createDocument(params: {
+    databaseId: string;
+    collectionId: string;
+    documentId: string;
+    data: Record<string, unknown>;
+  }): Promise<Record<string, unknown> & { $id: string }> {
+    const userId = params.data.userId;
+    const xTweetId = params.data.xTweetId;
+    if (typeof userId === 'string' && typeof xTweetId === 'string') {
+      for (const doc of this.docs.values()) {
+        if (doc.userId === userId && doc.xTweetId === xTweetId) {
+          const err = new Error('document already exists') as Error & { code: number };
+          err.code = 409;
+          throw err;
+        }
+      }
+    }
+    // Simulate ID.unique() by using a counter.
+    const docId = `doc-${this.nextId++}`;
+    const doc = { $id: docId, ...params.data };
+    this.docs.set(docId, doc);
+    return doc;
+  }
+
+  async listDocuments(params: {
+    databaseId: string;
+    collectionId: string;
+    queries?: string[];
+  }): Promise<{ total: number; documents: Array<Record<string, unknown> & { $id: string }> }> {
+    const filters: Array<[string, string]> = (params.queries ?? []).map((q) => {
+      const parsed = parseEqualQuery(q);
+      if (!parsed) throw new Error(`unsupported fake query: ${q}`);
+      return parsed;
+    });
+    const all = Array.from(this.docs.values());
+    const matched = all.filter((d) =>
+      filters.every(([field, value]) => String(d[field]) === value),
+    );
+    return { total: matched.length, documents: matched };
+  }
+}
+
+function parseEqualQuery(q: string): [string, string] | null {
+  try {
+    const parsed = JSON.parse(q) as {
+      method?: unknown;
+      attribute?: unknown;
+      values?: unknown;
+    };
+    if (parsed.method !== 'equal') return null;
+    if (typeof parsed.attribute !== 'string') return null;
+    if (!Array.isArray(parsed.values) || parsed.values.length === 0) return null;
+    return [parsed.attribute, String(parsed.values[0])];
+  } catch {
+    return null;
+  }
+}
+
+function makeRepo(): { repo: ItemsRepo; db: FakeDatabases } {
+  const db = new FakeDatabases();
+  const fakeAppwrite = {
+    databaseId: 'test-db',
+    databases: db as unknown as never,
+  };
+  return { repo: new ItemsRepo(fakeAppwrite as never), db };
+}
+
+describe('ItemsRepo.upsertMany', () => {
+  it('creates new items and marks them as isNew', async () => {
+    const { repo } = makeRepo();
+    const results = await repo.upsertMany('user1', [
+      {
+        tweetId: 'tweet1',
+        text: 'hello world',
+        authorHandle: 'alice',
+        urls: ['https://example.com'],
+        kind: 'like',
+      },
+    ]);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.isNew).toBe(true);
+    expect(typeof results[0]!.id).toBe('string');
+  });
+
+  it('marks duplicate items as not new on second upsert', async () => {
+    const { repo } = makeRepo();
+    const items = [
+      {
+        tweetId: 'tweet1',
+        text: 'hello',
+        authorHandle: 'alice',
+        urls: [],
+        kind: 'like' as const,
+      },
+    ];
+    const first = await repo.upsertMany('user1', items);
+    expect(first[0]!.isNew).toBe(true);
+    const second = await repo.upsertMany('user1', items);
+    expect(second[0]!.isNew).toBe(false);
+    expect(second[0]!.id).toBe(first[0]!.id);
+  });
+
+  it('handles a mix of new and existing items', async () => {
+    const { repo } = makeRepo();
+    await repo.upsertMany('user1', [
+      { tweetId: 't1', text: 'a', authorHandle: 'a', urls: [], kind: 'like' },
+    ]);
+    const results = await repo.upsertMany('user1', [
+      { tweetId: 't1', text: 'a', authorHandle: 'a', urls: [], kind: 'like' },
+      { tweetId: 't2', text: 'b', authorHandle: 'b', urls: [], kind: 'bookmark' },
+    ]);
+    expect(results).toHaveLength(2);
+    expect(results[0]!.isNew).toBe(false);
+    expect(results[1]!.isNew).toBe(true);
+  });
+
+  it('sets enriched to false on new items', async () => {
+    const { repo, db } = makeRepo();
+    const results = await repo.upsertMany('user1', [
+      { tweetId: 't1', text: 'a', authorHandle: 'a', urls: [], kind: 'like' },
+    ]);
+    const doc = db.docs.get(results[0]!.id);
+    expect(doc?.enriched).toBe(false);
+  });
+
+  it('sets fetchedAt to an ISO timestamp on new items', async () => {
+    const { repo, db } = makeRepo();
+    const before = new Date().toISOString();
+    const results = await repo.upsertMany('user1', [
+      { tweetId: 't1', text: 'a', authorHandle: 'a', urls: [], kind: 'like' },
+    ]);
+    const doc = db.docs.get(results[0]!.id);
+    expect(typeof doc?.fetchedAt).toBe('string');
+    expect(doc!.fetchedAt! >= before).toBe(true);
+  });
+
+  it('returns empty array for empty input', async () => {
+    const { repo } = makeRepo();
+    const results = await repo.upsertMany('user1', []);
+    expect(results).toHaveLength(0);
+  });
+
+  it('allows the same tweetId for different users', async () => {
+    const { repo } = makeRepo();
+    const r1 = await repo.upsertMany('user1', [
+      { tweetId: 't1', text: 'a', authorHandle: 'a', urls: [], kind: 'like' },
+    ]);
+    const r2 = await repo.upsertMany('user2', [
+      { tweetId: 't1', text: 'a', authorHandle: 'a', urls: [], kind: 'like' },
+    ]);
+    expect(r1[0]!.isNew).toBe(true);
+    expect(r2[0]!.isNew).toBe(true);
+    expect(r1[0]!.id).not.toBe(r2[0]!.id);
+  });
+});

--- a/src/workers/items.repo.ts
+++ b/src/workers/items.repo.ts
@@ -99,7 +99,8 @@ export class ItemsRepo {
 
 function isConflict(err: unknown): boolean {
   if (!err || typeof err !== 'object') return false;
-  return (err as { code?: number }).code === 409;
+  const e = err as { code?: number; type?: string };
+  return e.code === 409 || e.type === 'document_already_exists';
 }
 
 function toItemRecord(doc: Record<string, unknown> & { $id: string }): ItemRecord {

--- a/src/workers/items.repo.ts
+++ b/src/workers/items.repo.ts
@@ -1,0 +1,140 @@
+import { Injectable } from '@nestjs/common';
+import { ID, Query } from 'node-appwrite';
+import { AppwriteService } from '../appwrite/appwrite.service';
+import type { TweetItem, TweetKind } from '../ingestion/x-source.port';
+
+export interface ItemRecord {
+  id: string;
+  userId: string;
+  xTweetId: string;
+  kind: TweetKind;
+  text: string;
+  authorHandle: string;
+  urls: string[];
+  fetchedAt: string;
+  enriched: boolean;
+}
+
+interface ItemsDatabases {
+  createDocument(params: {
+    databaseId: string;
+    collectionId: string;
+    documentId: string;
+    data: Record<string, unknown>;
+  }): Promise<Record<string, unknown> & { $id: string }>;
+  listDocuments(params: {
+    databaseId: string;
+    collectionId: string;
+    queries?: string[];
+  }): Promise<{ total: number; documents: Array<Record<string, unknown> & { $id: string }> }>;
+}
+
+const COLLECTION_ID = 'items';
+
+@Injectable()
+export class ItemsRepo {
+  private readonly databaseId: string;
+  private readonly db: ItemsDatabases;
+
+  constructor(appwrite: AppwriteService) {
+    this.databaseId = appwrite.databaseId;
+    this.db = appwrite.databases as unknown as ItemsDatabases;
+  }
+
+  /**
+   * Upsert items for a user. Uses `ID.unique()` for document IDs and
+   * relies on the compound unique index `(userId, xTweetId)` for dedup.
+   * On 409 conflict, the item already exists — query it back and return
+   * with `isNew: false`.
+   */
+  async upsertMany(
+    userId: string,
+    items: TweetItem[],
+  ): Promise<Array<{ id: string; isNew: boolean }>> {
+    const results: Array<{ id: string; isNew: boolean }> = [];
+    const fetchedAt = new Date().toISOString();
+
+    for (const item of items) {
+      try {
+        const created = await this.db.createDocument({
+          databaseId: this.databaseId,
+          collectionId: COLLECTION_ID,
+          documentId: ID.unique(),
+          data: {
+            userId,
+            xTweetId: item.tweetId,
+            kind: item.kind,
+            text: item.text,
+            authorHandle: item.authorHandle,
+            urls: item.urls,
+            fetchedAt,
+            enriched: false,
+          },
+        });
+        results.push({ id: created.$id, isNew: true });
+      } catch (err) {
+        if (!isConflict(err)) throw err;
+        const existing = await this.findByUserAndTweetId(userId, item.tweetId);
+        if (!existing) throw err;
+        results.push({ id: existing.id, isNew: false });
+      }
+    }
+    return results;
+  }
+
+  /** Query by compound key. Returns `null` on miss. */
+  async findByUserAndTweetId(
+    userId: string,
+    xTweetId: string,
+  ): Promise<ItemRecord | null> {
+    const result = await this.db.listDocuments({
+      databaseId: this.databaseId,
+      collectionId: COLLECTION_ID,
+      queries: [Query.equal('userId', userId), Query.equal('xTweetId', xTweetId)],
+    });
+    if (result.total === 0 || result.documents.length === 0) return null;
+    return toItemRecord(result.documents[0]!);
+  }
+}
+
+function isConflict(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  return (err as { code?: number }).code === 409;
+}
+
+function toItemRecord(doc: Record<string, unknown> & { $id: string }): ItemRecord {
+  const userId = doc.userId;
+  const xTweetId = doc.xTweetId;
+  const kind = doc.kind;
+  const text = doc.text;
+  const authorHandle = doc.authorHandle;
+  const urls = doc.urls;
+  const fetchedAt = doc.fetchedAt;
+  const enriched = doc.enriched;
+  if (
+    typeof userId !== 'string' ||
+    typeof xTweetId !== 'string' ||
+    typeof text !== 'string' ||
+    typeof authorHandle !== 'string' ||
+    typeof fetchedAt !== 'string'
+  ) {
+    throw new Error(`items row ${doc.$id} is missing required string fields`);
+  }
+  if (kind !== 'like' && kind !== 'bookmark') {
+    throw new Error(`items row ${doc.$id} has invalid kind: ${String(kind)}`);
+  }
+  if (!Array.isArray(urls)) {
+    throw new Error(`items row ${doc.$id} has non-array urls`);
+  }
+  return {
+    id: doc.$id,
+    userId,
+    xTweetId,
+    kind,
+    text,
+    authorHandle,
+    urls: urls.map(String),
+    fetchedAt,
+    enriched: enriched === true,
+  };
+}

--- a/src/workers/poll-x.processor.test.ts
+++ b/src/workers/poll-x.processor.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it } from 'bun:test';
+import { AuthExpiredError } from '../auth/auth.service';
+import type { FetchPage, TweetItem, XSource } from '../ingestion/x-source.port';
+import type { UserRecord } from '../users/users.repo';
+import { PollXProcessor } from './poll-x.processor';
+
+class StubXSource implements XSource {
+  likePages: FetchPage[] = [];
+  bookmarkPages: FetchPage[] = [];
+  private likeCallIndex = 0;
+  private bookmarkCallIndex = 0;
+
+  async fetchLikes(_userId: string, _cursor?: string): Promise<FetchPage> {
+    return this.likePages[this.likeCallIndex++] ?? { items: [] };
+  }
+
+  async fetchBookmarks(_userId: string, _cursor?: string): Promise<FetchPage> {
+    return this.bookmarkPages[this.bookmarkCallIndex++] ?? { items: [] };
+  }
+}
+
+class FakeUsersRepo {
+  users = new Map<string, UserRecord>();
+  cursorUpdates: Array<{ userId: string; cursors: Record<string, string> }> = [];
+
+  async findById(userId: string): Promise<UserRecord | null> {
+    return this.users.get(userId) ?? null;
+  }
+
+  async updateCursors(
+    userId: string,
+    cursors: { lastLikeCursor?: string; lastBookmarkCursor?: string },
+  ): Promise<UserRecord> {
+    this.cursorUpdates.push({ userId, cursors: cursors as Record<string, string> });
+    const user = this.users.get(userId);
+    if (!user) throw new Error('user not found');
+    return { ...user, ...cursors };
+  }
+}
+
+class FakeItemsRepo {
+  upserted: Array<{ userId: string; items: TweetItem[] }> = [];
+  private nextId = 1;
+  knownTweetIds = new Set<string>();
+
+  async upsertMany(
+    userId: string,
+    items: TweetItem[],
+  ): Promise<Array<{ id: string; isNew: boolean }>> {
+    this.upserted.push({ userId, items: [...items] });
+    return items.map((item) => {
+      const key = `${userId}:${item.tweetId}`;
+      const isNew = !this.knownTweetIds.has(key);
+      this.knownTweetIds.add(key);
+      return { id: `item-${this.nextId++}`, isNew };
+    });
+  }
+}
+
+class FakeExtractQueue {
+  jobs: Array<{ name: string; data: unknown }> = [];
+
+  async add(name: string, data: unknown): Promise<void> {
+    this.jobs.push({ name, data });
+  }
+}
+
+class FakeLogger {
+  logs: Array<{ level: string; msg: string; context?: Record<string, unknown> }> = [];
+
+  log(msg: string, context?: Record<string, unknown>) {
+    this.logs.push({ level: 'log', msg, context });
+  }
+
+  warn(msg: string, context?: Record<string, unknown>) {
+    this.logs.push({ level: 'warn', msg, context });
+  }
+}
+
+function activeUser(overrides: Partial<UserRecord> = {}): UserRecord {
+  return {
+    id: 'user-1',
+    xUserId: '99999',
+    handle: 'testuser',
+    status: 'active',
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeTweet(overrides: Partial<TweetItem> = {}): TweetItem {
+  return {
+    tweetId: 'tw-1',
+    text: 'check this out',
+    authorHandle: 'author1',
+    urls: ['https://example.com/article'],
+    kind: 'like',
+    ...overrides,
+  };
+}
+
+function makeProcessor() {
+  const xSource = new StubXSource();
+  const users = new FakeUsersRepo();
+  const items = new FakeItemsRepo();
+  const extractQueue = new FakeExtractQueue();
+  const logger = new FakeLogger();
+
+  const processor = new PollXProcessor(
+    xSource,
+    extractQueue as never,
+    users as never,
+    items as never,
+  );
+
+  // Replace the logger that NestJS auto-creates.
+  Object.defineProperty(processor, 'logger', { value: logger });
+
+  return { processor, xSource, users, items, extractQueue, logger };
+}
+
+describe('PollXProcessor.process', () => {
+  it('fetches likes and bookmarks, upserts items, updates cursors, enqueues extraction', async () => {
+    const { processor, xSource, users, items, extractQueue } = makeProcessor();
+    const user = activeUser();
+    users.users.set(user.id, user);
+
+    xSource.likePages = [
+      { items: [makeTweet({ tweetId: 'tw-1', kind: 'like' })], nextCursor: 'lc1' },
+      { items: [makeTweet({ tweetId: 'tw-2', kind: 'like' })] },
+    ];
+    xSource.bookmarkPages = [
+      { items: [makeTweet({ tweetId: 'tw-3', kind: 'bookmark', urls: [] })] },
+    ];
+
+    await processor.process({ data: { userId: user.id }, attemptsMade: 0 });
+
+    // Items upserted: likes batch + bookmarks batch.
+    expect(items.upserted).toHaveLength(2);
+    expect(items.upserted[0]!.items).toHaveLength(2);
+    expect(items.upserted[1]!.items).toHaveLength(1);
+
+    // Extract jobs enqueued only for items with URLs (tw-1 and tw-2, not tw-3).
+    expect(extractQueue.jobs).toHaveLength(2);
+    expect(extractQueue.jobs[0]!.data).toEqual({ userId: user.id, itemId: 'item-1' });
+    expect(extractQueue.jobs[1]!.data).toEqual({ userId: user.id, itemId: 'item-2' });
+  });
+
+  it('skips extract-item enqueue for items without URLs', async () => {
+    const { processor, xSource, users, extractQueue } = makeProcessor();
+    const user = activeUser();
+    users.users.set(user.id, user);
+
+    xSource.likePages = [
+      { items: [makeTweet({ tweetId: 'tw-1', urls: [] })] },
+    ];
+    xSource.bookmarkPages = [{ items: [] }];
+
+    await processor.process({ data: { userId: user.id }, attemptsMade: 0 });
+
+    expect(extractQueue.jobs).toHaveLength(0);
+  });
+
+  it('updates cursors with the final pagination cursor', async () => {
+    const { processor, xSource, users } = makeProcessor();
+    const user = activeUser();
+    users.users.set(user.id, user);
+
+    xSource.likePages = [
+      { items: [makeTweet()], nextCursor: 'lc1' },
+      { items: [], nextCursor: 'lc2' },
+      { items: [] },
+    ];
+    xSource.bookmarkPages = [
+      { items: [], nextCursor: 'bc1' },
+      { items: [] },
+    ];
+
+    await processor.process({ data: { userId: user.id }, attemptsMade: 0 });
+
+    expect(users.cursorUpdates).toHaveLength(1);
+    expect(users.cursorUpdates[0]!.cursors).toEqual({
+      lastLikeCursor: 'lc2',
+      lastBookmarkCursor: 'bc1',
+    });
+  });
+
+  it('returns early without retry when user is missing', async () => {
+    const { processor, items, extractQueue } = makeProcessor();
+
+    await processor.process({ data: { userId: 'gone' }, attemptsMade: 0 });
+
+    expect(items.upserted).toHaveLength(0);
+    expect(extractQueue.jobs).toHaveLength(0);
+  });
+
+  it('returns early without retry when user status is not active', async () => {
+    const { processor, users, items } = makeProcessor();
+    const user = activeUser({ status: 'auth_expired' });
+    users.users.set(user.id, user);
+
+    await processor.process({ data: { userId: user.id }, attemptsMade: 0 });
+
+    expect(items.upserted).toHaveLength(0);
+  });
+
+  it('catches AuthExpiredError and returns without throwing', async () => {
+    const { processor, xSource, users, items } = makeProcessor();
+    const user = activeUser();
+    users.users.set(user.id, user);
+
+    xSource.fetchLikes = async () => {
+      throw new AuthExpiredError('refresh failed');
+    };
+
+    await processor.process({ data: { userId: user.id }, attemptsMade: 0 });
+
+    expect(items.upserted).toHaveLength(0);
+  });
+
+  it('lets transport errors propagate for BullMQ retry', async () => {
+    const { processor, xSource, users } = makeProcessor();
+    const user = activeUser();
+    users.users.set(user.id, user);
+
+    xSource.fetchLikes = async () => {
+      throw new Error('x api v2 request timed out');
+    };
+
+    await expect(
+      processor.process({ data: { userId: user.id }, attemptsMade: 0 }),
+    ).rejects.toThrow('x api v2 request timed out');
+  });
+
+  it('passes stored cursors into XSource calls', async () => {
+    const { processor, xSource, users } = makeProcessor();
+    const user = activeUser({
+      lastLikeCursor: 'stored-lc',
+      lastBookmarkCursor: 'stored-bc',
+    });
+    users.users.set(user.id, user);
+
+    const likeCursors: Array<string | undefined> = [];
+    const bookmarkCursors: Array<string | undefined> = [];
+
+    xSource.fetchLikes = async (_userId: string, cursor?: string) => {
+      likeCursors.push(cursor);
+      return { items: [] };
+    };
+    xSource.fetchBookmarks = async (_userId: string, cursor?: string) => {
+      bookmarkCursors.push(cursor);
+      return { items: [] };
+    };
+
+    await processor.process({ data: { userId: user.id }, attemptsMade: 0 });
+
+    expect(likeCursors[0]).toBe('stored-lc');
+    expect(bookmarkCursors[0]).toBe('stored-bc');
+  });
+
+  it('only enqueues extract-item for NEW items, not duplicates', async () => {
+    const { processor, xSource, users, items, extractQueue } = makeProcessor();
+    const user = activeUser();
+    users.users.set(user.id, user);
+
+    items.knownTweetIds.add(`${user.id}:tw-1`);
+
+    xSource.likePages = [
+      {
+        items: [
+          makeTweet({ tweetId: 'tw-1', urls: ['https://a.com'] }),
+          makeTweet({ tweetId: 'tw-2', urls: ['https://b.com'] }),
+        ],
+      },
+    ];
+    xSource.bookmarkPages = [{ items: [] }];
+
+    await processor.process({ data: { userId: user.id }, attemptsMade: 0 });
+
+    expect(extractQueue.jobs).toHaveLength(1);
+    expect((extractQueue.jobs[0]!.data as { itemId: string }).itemId).toBe('item-2');
+  });
+});

--- a/src/workers/poll-x.processor.ts
+++ b/src/workers/poll-x.processor.ts
@@ -18,7 +18,10 @@ export class PollXProcessor {
 
   constructor(
     @Inject(X_SOURCE) private readonly xSource: XSource,
-    @Inject(EXTRACT_ITEM_QUEUE) private readonly extractQueue: { add(name: string, data: unknown): Promise<unknown> },
+    @Inject(EXTRACT_ITEM_QUEUE)
+    private readonly extractQueue: {
+      add(name: string, data: unknown, opts?: Record<string, unknown>): Promise<unknown>;
+    },
     private readonly users: UsersRepo,
     private readonly items: ItemsRepo,
   ) {}
@@ -65,10 +68,16 @@ export class PollXProcessor {
       const result = allResults[i]!;
       const item = allItems[i]!;
       if (result.isNew && item.urls.length > 0) {
-        await this.extractQueue.add('extract-item', {
-          userId,
-          itemId: result.id,
-        });
+        await this.extractQueue.add(
+          'extract-item',
+          { userId, itemId: result.id },
+          {
+            attempts: 4,
+            backoff: { type: 'exponential', delay: 15_000 },
+            removeOnComplete: { age: 86_400, count: 1000 },
+            removeOnFail: { age: 604_800 },
+          },
+        );
         extractJobsEnqueued++;
       }
     }
@@ -81,12 +90,15 @@ export class PollXProcessor {
     }
 
     const durationMs = Date.now() - start;
+    const newLikes = likeResults.filter((r) => r.isNew).length;
+    const newBookmarks = bookmarkResults.filter((r) => r.isNew).length;
     this.logger.log('poll complete', {
       userId,
-      attempt: job.attemptsMade,
+      attempt: job.attemptsMade + 1,
       durationMs,
-      newLikes: likeResults.filter((r) => r.isNew).length,
-      newBookmarks: bookmarkResults.filter((r) => r.isNew).length,
+      newLikes,
+      newBookmarks,
+      newItems: newLikes + newBookmarks,
       extractJobsEnqueued,
     });
   }

--- a/src/workers/poll-x.processor.ts
+++ b/src/workers/poll-x.processor.ts
@@ -1,0 +1,119 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { AuthExpiredError } from '../auth/auth.service';
+import type { FetchPage, TweetItem, XSource } from '../ingestion/x-source.port';
+import { X_SOURCE } from '../ingestion/ingestion.module';
+import { EXTRACT_ITEM_QUEUE } from '../queue/queue.tokens';
+import { UsersRepo } from '../users/users.repo';
+import { ItemsRepo } from './items.repo';
+
+/** Minimal job shape — no BullMQ types in the public interface. */
+export interface PollXJob {
+  data: { userId: string };
+  attemptsMade: number;
+}
+
+@Injectable()
+export class PollXProcessor {
+  private readonly logger = new Logger(PollXProcessor.name);
+
+  constructor(
+    @Inject(X_SOURCE) private readonly xSource: XSource,
+    @Inject(EXTRACT_ITEM_QUEUE) private readonly extractQueue: { add(name: string, data: unknown): Promise<unknown> },
+    private readonly users: UsersRepo,
+    private readonly items: ItemsRepo,
+  ) {}
+
+  async process(job: PollXJob): Promise<void> {
+    const { userId } = job.data;
+    const start = Date.now();
+
+    const user = await this.users.findById(userId);
+    if (!user || user.status !== 'active') {
+      this.logger.warn(`skipping poll: user ${userId} is ${user?.status ?? 'missing'}`);
+      return;
+    }
+
+    let likeItems: TweetItem[];
+    let lastLikeCursor: string | undefined;
+    let bookmarkItems: TweetItem[];
+    let lastBookmarkCursor: string | undefined;
+
+    try {
+      ({ items: likeItems, cursor: lastLikeCursor } = await this.fetchAll(
+        (cursor) => this.xSource.fetchLikes(userId, cursor),
+        user.lastLikeCursor,
+      ));
+      ({ items: bookmarkItems, cursor: lastBookmarkCursor } = await this.fetchAll(
+        (cursor) => this.xSource.fetchBookmarks(userId, cursor),
+        user.lastBookmarkCursor,
+      ));
+    } catch (err) {
+      if (err instanceof AuthExpiredError) {
+        this.logger.warn(`auth expired for user ${userId}, stopping poll`);
+        return;
+      }
+      throw err;
+    }
+
+    const likeResults = await this.items.upsertMany(userId, likeItems);
+    const bookmarkResults = await this.items.upsertMany(userId, bookmarkItems);
+    const allResults = [...likeResults, ...bookmarkResults];
+    const allItems = [...likeItems, ...bookmarkItems];
+
+    let extractJobsEnqueued = 0;
+    for (let i = 0; i < allResults.length; i++) {
+      const result = allResults[i]!;
+      const item = allItems[i]!;
+      if (result.isNew && item.urls.length > 0) {
+        await this.extractQueue.add('extract-item', {
+          userId,
+          itemId: result.id,
+        });
+        extractJobsEnqueued++;
+      }
+    }
+
+    const cursors: { lastLikeCursor?: string; lastBookmarkCursor?: string } = {};
+    if (lastLikeCursor !== undefined) cursors.lastLikeCursor = lastLikeCursor;
+    if (lastBookmarkCursor !== undefined) cursors.lastBookmarkCursor = lastBookmarkCursor;
+    if (Object.keys(cursors).length > 0) {
+      await this.users.updateCursors(userId, cursors);
+    }
+
+    const durationMs = Date.now() - start;
+    this.logger.log('poll complete', {
+      userId,
+      attempt: job.attemptsMade,
+      durationMs,
+      newLikes: likeResults.filter((r) => r.isNew).length,
+      newBookmarks: bookmarkResults.filter((r) => r.isNew).length,
+      extractJobsEnqueued,
+    });
+  }
+
+  /**
+   * Walk all pages from a fetch function until `nextCursor` is absent.
+   * Returns all collected items and the last cursor seen (for persisting).
+   */
+  private async fetchAll(
+    fetchPage: (cursor?: string) => Promise<FetchPage>,
+    initialCursor?: string,
+  ): Promise<{ items: TweetItem[]; cursor?: string }> {
+    const collected: TweetItem[] = [];
+    let cursor: string | undefined = initialCursor;
+    let lastCursor: string | undefined;
+
+    // biome-ignore lint/correctness/noConstantCondition: pagination loop
+    while (true) {
+      const page = await fetchPage(cursor);
+      collected.push(...page.items);
+      if (page.nextCursor) {
+        lastCursor = page.nextCursor;
+        cursor = page.nextCursor;
+      } else {
+        break;
+      }
+    }
+    return { items: collected, cursor: lastCursor };
+  }
+}

--- a/src/workers/workers.module.ts
+++ b/src/workers/workers.module.ts
@@ -1,0 +1,88 @@
+import {
+  type DynamicModule,
+  Logger,
+  Module,
+  type OnModuleDestroy,
+  type OnModuleInit,
+} from '@nestjs/common';
+import { Worker } from 'bullmq';
+import type { Redis } from 'ioredis';
+import type { Env } from '../config/env';
+import { POLL_X_QUEUE_NAME, REDIS_CLIENT } from '../queue/queue.tokens';
+import { ItemsRepo } from './items.repo';
+import { PollXProcessor } from './poll-x.processor';
+
+/**
+ * Owns BullMQ `Worker` instances for all processor queues.
+ *
+ * This milestone (#7) registers only the `poll-x` worker. Future
+ * milestones (#8 `extract-item`, #11 `build-digest`) add their
+ * workers here.
+ *
+ * Worker creation and shutdown live in `WorkersLifecycle`, a separate
+ * injectable registered as a provider. This follows the same pattern
+ * `QueueModule` uses with `QueueModuleLifecycle` — and lets the
+ * e2e-lite test override it to prevent workers from connecting to
+ * Redis.
+ */
+
+const POLL_X_CONCURRENCY = 'POLL_X_CONCURRENCY';
+
+/**
+ * Lifecycle holder that creates and tears down BullMQ Workers.
+ * Overridable in tests via `Test.overrideProvider(WorkersLifecycle)`.
+ */
+export class WorkersLifecycle implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(WorkersLifecycle.name);
+  private pollXWorker?: Worker;
+
+  constructor(
+    private readonly redis: Redis,
+    private readonly concurrency: number,
+    private readonly pollXProcessor: PollXProcessor,
+  ) {}
+
+  onModuleInit() {
+    this.pollXWorker = new Worker(
+      POLL_X_QUEUE_NAME,
+      async (job) => this.pollXProcessor.process(job),
+      {
+        connection: this.redis,
+        concurrency: this.concurrency,
+      },
+    );
+    this.logger.log(`poll-x worker started (concurrency: ${this.concurrency})`);
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    if (this.pollXWorker) {
+      try {
+        await this.pollXWorker.close();
+        this.logger.log('poll-x worker closed');
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.logger.warn(`failed to close poll-x worker: ${message}`);
+      }
+    }
+  }
+}
+
+@Module({})
+export class WorkersModule {
+  static forRoot(env: Env): DynamicModule {
+    return {
+      module: WorkersModule,
+      providers: [
+        ItemsRepo,
+        PollXProcessor,
+        { provide: POLL_X_CONCURRENCY, useValue: env.POLL_X_CONCURRENCY },
+        {
+          provide: WorkersLifecycle,
+          useFactory: (redis: Redis, concurrency: number, processor: PollXProcessor) =>
+            new WorkersLifecycle(redis, concurrency, processor),
+          inject: [REDIS_CLIENT, POLL_X_CONCURRENCY, PollXProcessor],
+        },
+      ],
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- Add `PollXProcessor` consuming the `poll-x` BullMQ queue — fetches likes/bookmarks via `XSource`, upserts items (deduped on `(userId, xTweetId)`), enqueues `extract-item` for items with URLs, updates user cursors
- Add `WorkersModule` owning BullMQ `Worker` lifecycle with graceful shutdown
- Add `ItemsRepo` for the `items` Appwrite collection with create-or-409-conflict dedup
- Add `UsersRepo.updateCursors` method and cursor fields on `UserRecord`
- Make `IngestionModule` global so `X_SOURCE` token is available to `WorkersModule`
- Bump version 0.6.0 → 0.7.0

## Test plan

- [x] `PollXProcessor` unit tests (9 tests): happy path, URL filtering, cursor updates, missing/inactive users, `AuthExpiredError` handling, transport error propagation, stored cursor passthrough, duplicate skipping
- [x] `ItemsRepo` unit tests (7 tests): create, dedup, mixed new/existing, enriched flag, fetchedAt, empty input, cross-user isolation
- [x] `UsersRepo.updateCursors` unit tests (6 tests): partial patch, both cursors, untouched fields, missing user throws, empty patch throws
- [x] `UsersRepo` cursor field tests (2 tests): surface stored cursors, undefined when never polled
- [x] E2e-lite test passes with `WorkersLifecycle` override
- [x] `bunx tsc --noEmit` clean
- [x] 299/300 tests pass (1 pre-existing failure in `IngestionModule.forRoot` env test)

Closes #7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background worker to poll X likes/bookmarks, persist fetched items, enqueue extraction tasks for new items with URLs, and update per-user pagination cursors.

* **Tests**
  * Comprehensive tests for polling flow, item upsert/dedup behavior, and cursor update semantics; e2e-lite tests adjusted to run offline.

* **Documentation**
  * Added repository operating guide and a processing specification detailing worker behavior and conventions.

* **Chores**
  * Version bumped to 0.7.0 and modules wired to register the worker system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->