### PR TITLE
feat(digest): LlmProvider interface + OpenRouter impl (#9)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@ X_SCOPES=tweet.read users.read like.read bookmark.read offline.access
 
 # ----- LLM (default: openrouter) -----
 LLM_PROVIDER=openrouter
-OPENROUTER_API_KEY=
+OPENROUTER_API_KEY=          # required
 OPENROUTER_MODEL=anthropic/claude-sonnet-4.5
 
 # ----- Article extractor (default: firecrawl) -----

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "name": "x-reporter",
       "dependencies": {
+        "@langchain/core": "^0.3.0",
+        "@langchain/openai": "^0.5.0",
         "@nestjs/common": "11.1.18",
         "@nestjs/core": "11.1.18",
         "@nestjs/platform-express": "11.1.18",
@@ -48,7 +50,13 @@
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
+    "@cfworker/json-schema": ["@cfworker/json-schema@4.1.1", "", {}, "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og=="],
+
     "@ioredis/commands": ["@ioredis/commands@1.5.1", "", {}, "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw=="],
+
+    "@langchain/core": ["@langchain/core@0.3.80", "", { "dependencies": { "@cfworker/json-schema": "^4.0.2", "ansi-styles": "^5.0.0", "camelcase": "6", "decamelize": "1.2.0", "js-tiktoken": "^1.0.12", "langsmith": "^0.3.67", "mustache": "^4.2.0", "p-queue": "^6.6.2", "p-retry": "4", "uuid": "^10.0.0", "zod": "^3.25.32", "zod-to-json-schema": "^3.22.3" } }, "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA=="],
+
+    "@langchain/openai": ["@langchain/openai@0.5.18", "", { "dependencies": { "js-tiktoken": "^1.0.12", "openai": "^5.3.0", "zod": "^3.25.32" }, "peerDependencies": { "@langchain/core": ">=0.3.58 <0.4.0" } }, "sha512-CX1kOTbT5xVFNdtLjnM0GIYNf+P7oMSu+dGCFxxWRa3dZwWiuyuBXCm+dToUGxDLnsHuV1bKBtIzrY1mLq/A1Q=="],
 
     "@lukeed/csprng": ["@lukeed/csprng@1.1.0", "", {}, "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA=="],
 
@@ -84,11 +92,19 @@
 
     "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
+
+    "@types/uuid": ["@types/uuid@10.0.0", "", {}, "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="],
+
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "append-field": ["append-field@1.0.0", "", {}, "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="],
 
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
@@ -108,13 +124,23 @@
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
+    "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
+
+    "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
     "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
     "concat-stream": ["concat-stream@2.0.0", "", { "dependencies": { "buffer-from": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.0.2", "typedarray": "^0.0.6" } }, "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A=="],
 
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
+
+    "console-table-printer": ["console-table-printer@2.15.0", "", { "dependencies": { "simple-wcswidth": "^1.1.2" } }, "sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw=="],
 
     "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
 
@@ -131,6 +157,8 @@
     "dateformat": ["dateformat@4.6.3", "", {}, "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
 
     "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
@@ -156,6 +184,8 @@
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
+    "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
+
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
     "fast-copy": ["fast-copy@4.0.2", "", {}, "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw=="],
@@ -179,6 +209,8 @@
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
@@ -204,7 +236,11 @@
 
     "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
 
+    "js-tiktoken": ["js-tiktoken@1.0.21", "", { "dependencies": { "base64-js": "^1.5.1" } }, "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g=="],
+
     "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
+    "langsmith": ["langsmith@0.3.87", "", { "dependencies": { "@types/uuid": "^10.0.0", "chalk": "^4.1.2", "console-table-printer": "^2.12.1", "p-queue": "^6.6.2", "semver": "^7.6.3", "uuid": "^10.0.0" }, "peerDependencies": { "@opentelemetry/api": "*", "@opentelemetry/exporter-trace-otlp-proto": "*", "@opentelemetry/sdk-trace-base": "*", "openai": "*" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/exporter-trace-otlp-proto", "@opentelemetry/sdk-trace-base", "openai"] }, "sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q=="],
 
     "load-esm": ["load-esm@1.0.3", "", {}, "sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA=="],
 
@@ -234,6 +270,8 @@
 
     "multer": ["multer@2.1.1", "", { "dependencies": { "append-field": "^1.0.0", "busboy": "^1.6.0", "concat-stream": "^2.0.0", "type-is": "^1.6.18" } }, "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A=="],
 
+    "mustache": ["mustache@4.2.0", "", { "bin": { "mustache": "bin/mustache" } }, "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="],
+
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "nestjs-pino": ["nestjs-pino@4.6.1", "", { "peerDependencies": { "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0", "pino": "^7.5.0 || ^8.0.0 || ^9.0.0 || ^10.0.0", "pino-http": "^6.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0", "rxjs": "^7.1.0" } }, "sha512-nuARXa0xpdJ1lY2+fgycIQr6H3g0VgqAWNK3xMYjOFcj2DoPETNXj0lV3Y86nRuI7BUfQp5PGiVoZvT4dTWbpQ=="],
@@ -255,6 +293,16 @@
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "openai": ["openai@5.23.2", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg=="],
+
+    "p-finally": ["p-finally@1.0.0", "", {}, "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="],
+
+    "p-queue": ["p-queue@6.6.2", "", { "dependencies": { "eventemitter3": "^4.0.4", "p-timeout": "^3.2.0" } }, "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ=="],
+
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
+    "p-timeout": ["p-timeout@3.2.0", "", { "dependencies": { "p-finally": "^1.0.0" } }, "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
@@ -294,6 +342,8 @@
 
     "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
 
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
@@ -322,6 +372,8 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "simple-wcswidth": ["simple-wcswidth@1.1.2", "", {}, "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw=="],
+
     "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
@@ -337,6 +389,8 @@
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
     "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "thread-stream": ["thread-stream@4.0.0", "", { "dependencies": { "real-require": "^0.2.0" } }, "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA=="],
 
@@ -362,13 +416,23 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
-    "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+    "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@langchain/core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@langchain/openai/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "bullmq/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+
+    "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "multer/type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "setup:appwrite": "bun run scripts/setup-appwrite.ts"
   },
   "dependencies": {
+    "@langchain/core": "^0.3.0",
+    "@langchain/openai": "^0.5.0",
     "@nestjs/common": "11.1.18",
     "@nestjs/core": "11.1.18",
     "@nestjs/platform-express": "11.1.18",

--- a/src/app.module.test.ts
+++ b/src/app.module.test.ts
@@ -133,6 +133,10 @@ describe('AppModule (e2e-lite)', () => {
     process.env.X_SCOPES = 'tweet.read users.read offline.access';
     process.env.TOKEN_ENC_KEY = Buffer.alloc(32, 0).toString('base64');
     process.env.SESSION_SECRET = TEST_SESSION_SECRET;
+    // LLM vars are required as of milestone #9. The values don't need to
+    // be real — `LlmModule.forRoot` constructs the adapter lazily and no
+    // test in this e2e-lite suite calls the LLM.
+    process.env.OPENROUTER_API_KEY = 'test_openrouter_key';
 
     const { AppwriteService } = await import('./appwrite/appwrite.service');
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,7 @@ import { AuthModule } from './auth/auth.module';
 import { LoggerModule } from './common/logger';
 import { loadEnv } from './config/env';
 import { HealthModule } from './health/health.module';
+import { LlmModule } from './digest/llm/llm.module';
 import { IngestionModule } from './ingestion/ingestion.module';
 import { QueueModule } from './queue/queue.module';
 import { ScheduleModule } from './schedule/schedule.module';
@@ -17,7 +18,7 @@ import { WorkersModule } from './workers/workers.module';
  * Use `AppModule.forRoot()` from `main.ts` so the env is loaded once at boot
  * and passed into modules that need to be configured at construction time
  * (`LoggerModule`, `AppwriteModule`, `QueueModule`, `AuthModule`,
- * `UsersModule`, `IngestionModule`).
+ * `UsersModule`, `IngestionModule`, `LlmModule`).
  *
  * Module registration order:
  *   1. Foundations: `LoggerModule`, `AppwriteModule`, `QueueModule`.
@@ -66,6 +67,7 @@ export class AppModule {
         UsersModule.forRoot(env),
         IngestionModule.forRoot(env),
         WorkersModule.forRoot(env),
+        LlmModule.forRoot(env),
       ],
     };
   }

--- a/src/appwrite/appwrite.service.test.ts
+++ b/src/appwrite/appwrite.service.test.ts
@@ -16,6 +16,7 @@ const baseEnv = {
   TOKEN_ENC_KEY: Buffer.alloc(32, 0).toString('base64'),
   SESSION_SECRET: 'a-test-session-secret-at-least-32-chars-long',
   LLM_PROVIDER: 'openrouter' as const,
+  OPENROUTER_API_KEY: 'sk-or-test-key',
   OPENROUTER_MODEL: 'anthropic/claude-sonnet-4.5',
   EXTRACTOR: 'firecrawl' as const,
   POLL_X_CONCURRENCY: 5,

--- a/src/common/logger.test.ts
+++ b/src/common/logger.test.ts
@@ -67,6 +67,7 @@ describe('LoggerModule', () => {
       TOKEN_ENC_KEY: Buffer.alloc(32, 0).toString('base64'),
       SESSION_SECRET: 'a-test-session-secret-at-least-32-chars-long',
       LLM_PROVIDER: 'openrouter',
+      OPENROUTER_API_KEY: 'sk-or-test-key',
       OPENROUTER_MODEL: 'anthropic/claude-sonnet-4.5',
       EXTRACTOR: 'firecrawl',
       POLL_X_CONCURRENCY: 5,

--- a/src/config/env.test.ts
+++ b/src/config/env.test.ts
@@ -9,7 +9,7 @@ const TEST_TOKEN_ENC_KEY = Buffer.alloc(32, 0).toString('base64');
 const TEST_SESSION_SECRET = 'a-test-session-secret-at-least-32-chars-long';
 
 /**
- * Minimal env with all required vars present as of milestone #3. Tests
+ * Minimal env with all required vars present as of milestone #9. Tests
  * spread this and override or omit as needed.
  */
 const baseEnv = {
@@ -24,6 +24,7 @@ const baseEnv = {
   X_SCOPES: 'tweet.read users.read offline.access',
   TOKEN_ENC_KEY: TEST_TOKEN_ENC_KEY,
   SESSION_SECRET: TEST_SESSION_SECRET,
+  OPENROUTER_API_KEY: 'sk-or-test-key',
 };
 
 describe('loadEnv', () => {
@@ -217,5 +218,24 @@ describe('loadEnv', () => {
     expect(() => loadEnv({ ...baseEnv, SESSION_SECRET: 'too-short' })).toThrow(
       /SESSION_SECRET/,
     );
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // Milestone #9: LLM vars become required
+  // ────────────────────────────────────────────────────────────────────
+
+  it('throws when OPENROUTER_API_KEY is missing', () => {
+    const { OPENROUTER_API_KEY: _omit, ...rest } = baseEnv;
+    expect(() => loadEnv(rest)).toThrow(/OPENROUTER_API_KEY/);
+  });
+
+  it('defaults LLM_PROVIDER to openrouter', () => {
+    const env = loadEnv(baseEnv);
+    expect(env.LLM_PROVIDER).toBe('openrouter');
+  });
+
+  it('defaults OPENROUTER_MODEL to anthropic/claude-sonnet-4.5', () => {
+    const env = loadEnv(baseEnv);
+    expect(env.OPENROUTER_MODEL).toBe('anthropic/claude-sonnet-4.5');
   });
 });

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -5,8 +5,10 @@ import { z } from 'zod';
  *
  * Several fields are still optional in this milestone and will be
  * tightened to required as their owning milestones land:
- *   - LLM vars       -> required by issue #9
  *   - Firecrawl vars -> required by issue #8
+ *
+ * Required as of milestone #9 (LlmProvider):
+ *   - OPENROUTER_API_KEY
  *
  * Required as of milestone #2 (Appwrite bootstrap):
  *   - APPWRITE_ENDPOINT
@@ -90,7 +92,7 @@ const EnvSchema = z.object({
 
   // ----- LLM (#9) -----
   LLM_PROVIDER: z.enum(['openrouter']).default('openrouter'),
-  OPENROUTER_API_KEY: z.string().min(1).optional(),
+  OPENROUTER_API_KEY: z.string().min(1),
   OPENROUTER_MODEL: z.string().min(1).default('anthropic/claude-sonnet-4.5'),
 
   // ----- Article extractor (#8) -----

--- a/src/digest/llm/index.ts
+++ b/src/digest/llm/index.ts
@@ -1,23 +1,5 @@
 export type { LlmProvider, ChatOptions, ChatResult, ChatMessage } from './llm-provider.interface';
 export { OpenRouterProvider } from './openrouter.provider';
-export { LlmModule, LLM_PROVIDER } from './llm.module';
-
-import type { Env } from '../../config/env';
-import type { LlmProvider } from './llm-provider.interface';
-import { OpenRouterProvider } from './openrouter.provider';
-
-/**
- * Factory that returns the concrete `LlmProvider` selected by
- * `env.LLM_PROVIDER`. Called once at boot by `LlmModule.forRoot`.
- */
-export function createLlmProvider(env: Env): LlmProvider {
-  switch (env.LLM_PROVIDER) {
-    case 'openrouter':
-      return new OpenRouterProvider({
-        apiKey: env.OPENROUTER_API_KEY,
-        model: env.OPENROUTER_MODEL,
-      });
-    default:
-      throw new Error(`Unknown LLM_PROVIDER: ${env.LLM_PROVIDER}`);
-  }
-}
+export { LlmModule } from './llm.module';
+export { LLM_PROVIDER } from './llm.tokens';
+export { createLlmProvider } from './llm.factory';

--- a/src/digest/llm/index.ts
+++ b/src/digest/llm/index.ts
@@ -1,0 +1,23 @@
+export type { LlmProvider, ChatOptions, ChatResult, ChatMessage } from './llm-provider.interface';
+export { OpenRouterProvider } from './openrouter.provider';
+export { LlmModule, LLM_PROVIDER } from './llm.module';
+
+import type { Env } from '../../config/env';
+import type { LlmProvider } from './llm-provider.interface';
+import { OpenRouterProvider } from './openrouter.provider';
+
+/**
+ * Factory that returns the concrete `LlmProvider` selected by
+ * `env.LLM_PROVIDER`. Called once at boot by `LlmModule.forRoot`.
+ */
+export function createLlmProvider(env: Env): LlmProvider {
+  switch (env.LLM_PROVIDER) {
+    case 'openrouter':
+      return new OpenRouterProvider({
+        apiKey: env.OPENROUTER_API_KEY,
+        model: env.OPENROUTER_MODEL,
+      });
+    default:
+      throw new Error(`Unknown LLM_PROVIDER: ${env.LLM_PROVIDER}`);
+  }
+}

--- a/src/digest/llm/llm-factory.test.ts
+++ b/src/digest/llm/llm-factory.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, mock } from 'bun:test';
+
+// Mock langchain before importing factory
+mock.module('@langchain/openai', () => ({
+  ChatOpenAI: class FakeChatOpenAI {
+    bind() {
+      return { invoke: async () => ({ content: '', response_metadata: {} }) };
+    }
+  },
+}));
+
+mock.module('@langchain/core/messages', () => ({
+  SystemMessage: class {},
+  HumanMessage: class {},
+  AIMessage: class {},
+}));
+
+const { createLlmProvider } = await import('./index');
+const { OpenRouterProvider } = await import('./openrouter.provider');
+
+/** Minimal Env stub — only the fields `createLlmProvider` reads. */
+function makeEnv(overrides: Record<string, unknown> = {}) {
+  return {
+    LLM_PROVIDER: 'openrouter',
+    OPENROUTER_API_KEY: 'sk-test',
+    OPENROUTER_MODEL: 'anthropic/claude-sonnet-4.5',
+    ...overrides,
+  } as Parameters<typeof createLlmProvider>[0];
+}
+
+describe('createLlmProvider', () => {
+  it('returns an OpenRouterProvider when LLM_PROVIDER is "openrouter"', () => {
+    const provider = createLlmProvider(makeEnv());
+    expect(provider).toBeInstanceOf(OpenRouterProvider);
+    expect(provider.model).toBe('anthropic/claude-sonnet-4.5');
+  });
+
+  it('throws for an unknown provider', () => {
+    expect(() => createLlmProvider(makeEnv({ LLM_PROVIDER: 'nope' }))).toThrow(
+      'Unknown LLM_PROVIDER: nope',
+    );
+  });
+});

--- a/src/digest/llm/llm-provider.interface.ts
+++ b/src/digest/llm/llm-provider.interface.ts
@@ -1,0 +1,32 @@
+/**
+ * Port interface for LLM interactions.
+ *
+ * Framework-agnostic: no NestJS, LangChain, or vendor types leak through
+ * this boundary. Adapters live behind the interface and are selected at
+ * boot by the factory in `./index.ts`.
+ *
+ * See `docs/interfaces.md` section 3 for the full swap-point contract.
+ */
+
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface ChatOptions {
+  system?: string;
+  messages: ChatMessage[];
+  responseFormat?: 'text' | 'json';
+  temperature?: number;
+  maxTokens?: number;
+}
+
+export interface ChatResult {
+  content: string;
+  usage: { tokensIn: number; tokensOut: number };
+}
+
+export interface LlmProvider {
+  readonly model: string;
+  chat(opts: ChatOptions): Promise<ChatResult>;
+}

--- a/src/digest/llm/llm.factory.ts
+++ b/src/digest/llm/llm.factory.ts
@@ -1,0 +1,19 @@
+import type { Env } from '../../config/env';
+import type { LlmProvider } from './llm-provider.interface';
+import { OpenRouterProvider } from './openrouter.provider';
+
+/**
+ * Factory that returns the concrete `LlmProvider` selected by
+ * `env.LLM_PROVIDER`. Called once at boot by `LlmModule.forRoot`.
+ */
+export function createLlmProvider(env: Env): LlmProvider {
+  switch (env.LLM_PROVIDER) {
+    case 'openrouter':
+      return new OpenRouterProvider({
+        apiKey: env.OPENROUTER_API_KEY,
+        model: env.OPENROUTER_MODEL,
+      });
+    default:
+      throw new Error(`Unknown LLM_PROVIDER: ${env.LLM_PROVIDER}`);
+  }
+}

--- a/src/digest/llm/llm.module.ts
+++ b/src/digest/llm/llm.module.ts
@@ -1,0 +1,37 @@
+import { type DynamicModule, Module } from '@nestjs/common';
+import type { Env } from '../../config/env';
+import { createLlmProvider } from './index';
+
+/**
+ * DI token for the `LlmProvider` port. Consumers inject the provider
+ * via `@Inject(LLM_PROVIDER)` without referencing the concrete class.
+ *
+ * Follows the same naming convention as `X_SOURCE` in
+ * `src/ingestion/ingestion.module.ts` and `X_OAUTH_CLIENT` in
+ * `src/auth/auth.module.ts`.
+ */
+export const LLM_PROVIDER = 'LlmProvider';
+
+/**
+ * Wires the LLM provider into the NestJS DI container.
+ *
+ * `forRoot(env)` builds the concrete adapter once via `createLlmProvider`
+ * and exposes it under the `LLM_PROVIDER` token. The digest graph nodes
+ * (milestone #10+) inject this token to call the LLM without knowing
+ * which vendor is behind it.
+ */
+@Module({})
+export class LlmModule {
+  static forRoot(env: Env): DynamicModule {
+    return {
+      module: LlmModule,
+      providers: [
+        {
+          provide: LLM_PROVIDER,
+          useFactory: () => createLlmProvider(env),
+        },
+      ],
+      exports: [LLM_PROVIDER],
+    };
+  }
+}

--- a/src/digest/llm/llm.module.ts
+++ b/src/digest/llm/llm.module.ts
@@ -1,16 +1,7 @@
 import { type DynamicModule, Module } from '@nestjs/common';
 import type { Env } from '../../config/env';
-import { createLlmProvider } from './index';
-
-/**
- * DI token for the `LlmProvider` port. Consumers inject the provider
- * via `@Inject(LLM_PROVIDER)` without referencing the concrete class.
- *
- * Follows the same naming convention as `X_SOURCE` in
- * `src/ingestion/ingestion.module.ts` and `X_OAUTH_CLIENT` in
- * `src/auth/auth.module.ts`.
- */
-export const LLM_PROVIDER = 'LlmProvider';
+import { createLlmProvider } from './llm.factory';
+import { LLM_PROVIDER } from './llm.tokens';
 
 /**
  * Wires the LLM provider into the NestJS DI container.

--- a/src/digest/llm/llm.tokens.ts
+++ b/src/digest/llm/llm.tokens.ts
@@ -1,0 +1,13 @@
+/**
+ * DI token for the `LlmProvider` port. Consumers inject the provider
+ * via `@Inject(LLM_PROVIDER)` without referencing the concrete class.
+ *
+ * Lives in its own file to avoid a circular dependency between
+ * `llm.module.ts` (which imports `createLlmProvider` from `./index`)
+ * and `./index.ts` (which re-exports `LLM_PROVIDER`).
+ *
+ * Follows the same naming convention as `X_SOURCE` in
+ * `src/ingestion/ingestion.module.ts` and `X_OAUTH_CLIENT` in
+ * `src/auth/auth.module.ts`.
+ */
+export const LLM_PROVIDER = 'LlmProvider';

--- a/src/digest/llm/openrouter.provider.test.ts
+++ b/src/digest/llm/openrouter.provider.test.ts
@@ -93,6 +93,7 @@ describe('OpenRouterProvider', () => {
     expect(capturedCtorArgs).toMatchObject({
       modelName: 'anthropic/claude-sonnet-4.5',
       openAIApiKey: 'sk-test-key',
+      timeout: 60_000,
       configuration: {
         baseURL: 'https://openrouter.ai/api/v1',
         defaultHeaders: {
@@ -207,6 +208,29 @@ describe('OpenRouterProvider', () => {
     expect(msgs[0]?.content).toBe('Hello');
     expect(msgs[1]?.content).toBe('Hi there');
     expect(msgs[2]?.content).toBe('Follow up');
+  });
+
+  it('falls back to JSON.stringify when content is not a string', async () => {
+    const complexContent = [{ type: 'text', text: 'structured response' }];
+    // biome-ignore lint/suspicious/noExplicitAny: test mock needs flexible typing
+    fakeInvoke.mockImplementationOnce(async (): Promise<any> => ({
+      content: complexContent,
+      response_metadata: {
+        usage: { prompt_tokens: 10, completion_tokens: 5 },
+      },
+    }));
+
+    const provider = new OpenRouterProvider({
+      apiKey: 'sk-test',
+      model: 'test/model',
+    });
+
+    const result = await provider.chat({
+      messages: [{ role: 'user', content: 'Hello' }],
+    });
+
+    expect(result.content).toBe(JSON.stringify(complexContent));
+    expect(result.usage).toEqual({ tokensIn: 10, tokensOut: 5 });
   });
 
   it('does not pass response_format for text mode', async () => {

--- a/src/digest/llm/openrouter.provider.test.ts
+++ b/src/digest/llm/openrouter.provider.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { ChatOptions } from './llm-provider.interface';
+
+/**
+ * Unit tests for `OpenRouterProvider`.
+ *
+ * Strategy: mock the `@langchain/openai` `ChatOpenAI` class at the module
+ * level so no HTTP call leaves the process. The mock captures constructor
+ * args and `.bind().invoke()` calls, then returns a canned response that
+ * mirrors what OpenRouter / LangChain would produce.
+ */
+
+// --- Mock setup --------------------------------------------------------
+
+const invokeResult = {
+  content: 'Hello from the LLM',
+  response_metadata: {
+    usage: {
+      prompt_tokens: 42,
+      completion_tokens: 17,
+    },
+  },
+};
+
+let capturedCtorArgs: unknown;
+let capturedBindArgs: unknown;
+let capturedInvokeArgs: unknown;
+
+// biome-ignore lint/suspicious/noExplicitAny: test mock needs flexible typing
+const fakeInvoke = mock(async (msgs: unknown): Promise<any> => {
+  capturedInvokeArgs = msgs;
+  return invokeResult;
+});
+
+const fakeBind = mock((args: unknown) => {
+  capturedBindArgs = args;
+  return { invoke: fakeInvoke };
+});
+
+class FakeChatOpenAI {
+  constructor(args: unknown) {
+    capturedCtorArgs = args;
+  }
+  bind = fakeBind;
+}
+
+// Mock the langchain module before importing the provider
+mock.module('@langchain/openai', () => ({
+  ChatOpenAI: FakeChatOpenAI,
+}));
+
+mock.module('@langchain/core/messages', () => ({
+  SystemMessage: class SystemMessage {
+    content: string;
+    constructor(content: string) {
+      this.content = content;
+    }
+  },
+  HumanMessage: class HumanMessage {
+    content: string;
+    constructor(content: string) {
+      this.content = content;
+    }
+  },
+  AIMessage: class AIMessage {
+    content: string;
+    constructor(content: string) {
+      this.content = content;
+    }
+  },
+}));
+
+// Import after mocks are registered
+const { OpenRouterProvider } = await import('./openrouter.provider');
+
+// --- Tests -------------------------------------------------------------
+
+describe('OpenRouterProvider', () => {
+  beforeEach(() => {
+    capturedCtorArgs = undefined;
+    capturedBindArgs = undefined;
+    capturedInvokeArgs = undefined;
+    fakeInvoke.mockClear();
+    fakeBind.mockClear();
+  });
+
+  it('configures ChatOpenAI with OpenRouter baseURL and headers', () => {
+    new OpenRouterProvider({
+      apiKey: 'sk-test-key',
+      model: 'anthropic/claude-sonnet-4.5',
+    });
+
+    expect(capturedCtorArgs).toMatchObject({
+      modelName: 'anthropic/claude-sonnet-4.5',
+      openAIApiKey: 'sk-test-key',
+      configuration: {
+        baseURL: 'https://openrouter.ai/api/v1',
+        defaultHeaders: {
+          'HTTP-Referer': 'https://github.com/fusuyfusuy/x-reporter',
+          'X-Title': 'x-reporter',
+        },
+      },
+    });
+  });
+
+  it('exposes the model name', () => {
+    const provider = new OpenRouterProvider({
+      apiKey: 'sk-test',
+      model: 'openai/gpt-4o',
+    });
+    expect(provider.model).toBe('openai/gpt-4o');
+  });
+
+  it('sends system + user messages and returns content + usage', async () => {
+    const provider = new OpenRouterProvider({
+      apiKey: 'sk-test',
+      model: 'anthropic/claude-sonnet-4.5',
+    });
+
+    const opts: ChatOptions = {
+      system: 'You are helpful.',
+      messages: [{ role: 'user', content: 'Hi' }],
+    };
+
+    const result = await provider.chat(opts);
+
+    expect(result.content).toBe('Hello from the LLM');
+    expect(result.usage).toEqual({ tokensIn: 42, tokensOut: 17 });
+
+    // Verify messages were built correctly
+    const msgs = capturedInvokeArgs as Array<{ content: string }>;
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0]?.content).toBe('You are helpful.');
+    expect(msgs[1]?.content).toBe('Hi');
+  });
+
+  it('passes responseFormat json as response_format bind param', async () => {
+    const provider = new OpenRouterProvider({
+      apiKey: 'sk-test',
+      model: 'test/model',
+    });
+
+    await provider.chat({
+      messages: [{ role: 'user', content: 'Return JSON' }],
+      responseFormat: 'json',
+    });
+
+    expect(capturedBindArgs).toMatchObject({
+      response_format: { type: 'json_object' },
+    });
+  });
+
+  it('passes temperature and maxTokens to bind', async () => {
+    const provider = new OpenRouterProvider({
+      apiKey: 'sk-test',
+      model: 'test/model',
+    });
+
+    await provider.chat({
+      messages: [{ role: 'user', content: 'Hello' }],
+      temperature: 0.3,
+      maxTokens: 1024,
+    });
+
+    expect(capturedBindArgs).toMatchObject({
+      temperature: 0.3,
+      max_tokens: 1024,
+    });
+  });
+
+  it('handles missing usage gracefully (defaults to 0)', async () => {
+    // Override invoke to return no usage metadata
+    // biome-ignore lint/suspicious/noExplicitAny: test mock needs flexible typing
+    fakeInvoke.mockImplementationOnce(async (): Promise<any> => ({
+      content: 'No usage info',
+      response_metadata: {},
+    }));
+
+    const provider = new OpenRouterProvider({
+      apiKey: 'sk-test',
+      model: 'test/model',
+    });
+
+    const result = await provider.chat({
+      messages: [{ role: 'user', content: 'Hello' }],
+    });
+
+    expect(result.usage).toEqual({ tokensIn: 0, tokensOut: 0 });
+  });
+
+  it('handles assistant messages in the conversation', async () => {
+    const provider = new OpenRouterProvider({
+      apiKey: 'sk-test',
+      model: 'test/model',
+    });
+
+    await provider.chat({
+      messages: [
+        { role: 'user', content: 'Hello' },
+        { role: 'assistant', content: 'Hi there' },
+        { role: 'user', content: 'Follow up' },
+      ],
+    });
+
+    const msgs = capturedInvokeArgs as Array<{ content: string }>;
+    expect(msgs).toHaveLength(3);
+    expect(msgs[0]?.content).toBe('Hello');
+    expect(msgs[1]?.content).toBe('Hi there');
+    expect(msgs[2]?.content).toBe('Follow up');
+  });
+
+  it('does not pass response_format for text mode', async () => {
+    const provider = new OpenRouterProvider({
+      apiKey: 'sk-test',
+      model: 'test/model',
+    });
+
+    await provider.chat({
+      messages: [{ role: 'user', content: 'Hello' }],
+      responseFormat: 'text',
+    });
+
+    expect(capturedBindArgs).toEqual({});
+  });
+});

--- a/src/digest/llm/openrouter.provider.ts
+++ b/src/digest/llm/openrouter.provider.ts
@@ -1,0 +1,97 @@
+import { ChatOpenAI } from '@langchain/openai';
+import { HumanMessage, SystemMessage, AIMessage } from '@langchain/core/messages';
+import type { ChatOptions, ChatResult, LlmProvider } from './llm-provider.interface';
+
+/**
+ * Configuration extracted from `Env` so the adapter never imports the
+ * config module directly. The factory in `./index.ts` bridges the two.
+ */
+export interface OpenRouterConfig {
+  apiKey: string;
+  model: string;
+}
+
+/**
+ * Default `LlmProvider` adapter — wraps `@langchain/openai` `ChatOpenAI`
+ * pointed at the OpenRouter API.
+ *
+ * OpenRouter conventions applied:
+ *   - `baseURL` → `https://openrouter.ai/api/v1`
+ *   - `HTTP-Referer` header so OpenRouter can attribute traffic
+ *   - `X-Title` header for the OpenRouter dashboard
+ *
+ * Token accounting is read from the LangChain response metadata
+ * (`response_metadata.usage`), which OpenRouter populates in the
+ * standard OpenAI shape.
+ */
+export class OpenRouterProvider implements LlmProvider {
+  readonly model: string;
+  private readonly client: ChatOpenAI;
+
+  constructor(config: OpenRouterConfig) {
+    this.model = config.model;
+    this.client = new ChatOpenAI({
+      modelName: config.model,
+      openAIApiKey: config.apiKey,
+      configuration: {
+        baseURL: 'https://openrouter.ai/api/v1',
+        defaultHeaders: {
+          'HTTP-Referer': 'https://github.com/fusuyfusuy/x-reporter',
+          'X-Title': 'x-reporter',
+        },
+      },
+    });
+  }
+
+  async chat(opts: ChatOptions): Promise<ChatResult> {
+    const messages = this.buildMessages(opts);
+
+    const bound = this.client.bind({
+      ...(opts.responseFormat === 'json'
+        ? { response_format: { type: 'json_object' as const } }
+        : {}),
+      ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+      ...(opts.maxTokens !== undefined ? { max_tokens: opts.maxTokens } : {}),
+    });
+
+    const response = await bound.invoke(messages);
+
+    const content =
+      typeof response.content === 'string'
+        ? response.content
+        : JSON.stringify(response.content);
+
+    // LangChain populates `response_metadata.usage` from the OpenAI-compatible
+    // response body. OpenRouter follows the same shape.
+    const usage = (response.response_metadata?.usage ?? {}) as {
+      prompt_tokens?: number;
+      completion_tokens?: number;
+    };
+
+    return {
+      content,
+      usage: {
+        tokensIn: usage.prompt_tokens ?? 0,
+        tokensOut: usage.completion_tokens ?? 0,
+      },
+    };
+  }
+
+  private buildMessages(opts: ChatOptions) {
+    const msgs: (SystemMessage | HumanMessage | AIMessage)[] = [];
+
+    if (opts.system) {
+      msgs.push(new SystemMessage(opts.system));
+    }
+
+    for (const m of opts.messages) {
+      if (m.role === 'user') {
+        msgs.push(new HumanMessage(m.content));
+      } else {
+        msgs.push(new AIMessage(m.content));
+      }
+    }
+
+    return msgs;
+  }
+}

--- a/src/digest/llm/openrouter.provider.ts
+++ b/src/digest/llm/openrouter.provider.ts
@@ -33,6 +33,7 @@ export class OpenRouterProvider implements LlmProvider {
     this.client = new ChatOpenAI({
       modelName: config.model,
       openAIApiKey: config.apiKey,
+      timeout: 60_000,
       configuration: {
         baseURL: 'https://openrouter.ai/api/v1',
         defaultHeaders: {


### PR DESCRIPTION
## Summary

- Defines the `LlmProvider` port interface (`src/digest/llm/llm-provider.interface.ts`) per `docs/interfaces.md` -- framework-agnostic, no LangChain types in the contract
- Implements `OpenRouterProvider` wrapping `@langchain/openai` `ChatOpenAI` with `baseURL: https://openrouter.ai/api/v1`, `HTTP-Referer` and `X-Title` headers per OpenRouter conventions
- Returns `{ content, usage: { tokensIn, tokensOut } }` with token counts from the OpenRouter response metadata
- Adds `createLlmProvider(env)` factory in `src/digest/llm/index.ts` dispatching on `LLM_PROVIDER` env var
- Wires `LlmModule.forRoot(env)` into `AppModule` with `LLM_PROVIDER` DI token for injection
- Makes `OPENROUTER_API_KEY` required in `src/config/env.ts` (milestone #9 boundary)
- Bumps version from 0.6.0 to 0.7.0

## Test plan

- [x] Unit tests for `OpenRouterProvider` with mocked `ChatOpenAI` -- verifies constructor config, message building, response format passthrough, temperature/maxTokens binding, missing usage fallback, and multi-turn conversations
- [x] Unit tests for `createLlmProvider` factory -- verifies OpenRouter dispatch and unknown provider error
- [x] Updated `env.test.ts` with tests for required `OPENROUTER_API_KEY` and LLM defaults
- [x] Updated `app.module.test.ts`, `appwrite.service.test.ts`, `logger.test.ts` to include required `OPENROUTER_API_KEY`
- [x] `bunx tsc --noEmit` passes clean
- [x] `bunx biome lint .` -- no new warnings (all warnings are pre-existing)
- [x] `bun test` -- 288 pass, 1 pre-existing fail (IngestionModule, needs Redis)

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated LLM-powered chat support with text/JSON response modes, usage reporting, and OpenRouter as the default provider.

* **Tests**
  * Added unit and integration tests for provider selection, request shaping, response parsing, and error scenarios.

* **Chores**
  * Added runtime LLM dependencies and updated env example; OPENROUTER_API_KEY is now required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->