### PR TITLE
feat(digest): LangGraph DigestGraph (#10)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "x-reporter",
       "dependencies": {
         "@langchain/core": "^0.3.0",
+        "@langchain/langgraph": "^1.2.8",
         "@langchain/openai": "^0.5.0",
         "@nestjs/common": "11.1.18",
         "@nestjs/core": "11.1.18",
@@ -56,6 +57,12 @@
 
     "@langchain/core": ["@langchain/core@0.3.80", "", { "dependencies": { "@cfworker/json-schema": "^4.0.2", "ansi-styles": "^5.0.0", "camelcase": "6", "decamelize": "1.2.0", "js-tiktoken": "^1.0.12", "langsmith": "^0.3.67", "mustache": "^4.2.0", "p-queue": "^6.6.2", "p-retry": "4", "uuid": "^10.0.0", "zod": "^3.25.32", "zod-to-json-schema": "^3.22.3" } }, "sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA=="],
 
+    "@langchain/langgraph": ["@langchain/langgraph@1.2.8", "", { "dependencies": { "@langchain/langgraph-checkpoint": "^1.0.1", "@langchain/langgraph-sdk": "~1.8.8", "@standard-schema/spec": "1.1.0", "uuid": "^10.0.0" }, "peerDependencies": { "@langchain/core": "^1.1.16", "zod": "^3.25.32 || ^4.2.0", "zod-to-json-schema": "^3.x" }, "optionalPeers": ["zod-to-json-schema"] }, "sha512-kKkRpC5xFz1e6vPivE7lwRJa5oahLAMaVQvVGZdTa6uJIchIYJDIuM1n93FqGvg8aYVcgYU4FENtKKC5Eh1JYw=="],
+
+    "@langchain/langgraph-checkpoint": ["@langchain/langgraph-checkpoint@1.0.1", "", { "dependencies": { "uuid": "^10.0.0" }, "peerDependencies": { "@langchain/core": "^1.0.1" } }, "sha512-HM0cJLRpIsSlWBQ/xuDC67l52SqZ62Bh2Y61DX+Xorqwoh5e1KxYvfCD7GnSTbWWhjBOutvnR0vPhu4orFkZfw=="],
+
+    "@langchain/langgraph-sdk": ["@langchain/langgraph-sdk@1.8.8", "", { "dependencies": { "@types/json-schema": "^7.0.15", "p-queue": "^9.0.1", "p-retry": "^7.1.1", "uuid": "^13.0.0" }, "peerDependencies": { "@langchain/core": "^1.1.16", "react": "^18 || ^19", "react-dom": "^18 || ^19", "svelte": "^4.0.0 || ^5.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@langchain/core", "react", "react-dom", "svelte", "vue"] }, "sha512-4OoqFAvPloOTZ6oPxXbJngz4FLJO8QSXb+BQV3qvNTvmfu1LQA7cCEqSNLYX9MoC340PbnDkHNgUtjajwkDHRg=="],
+
     "@langchain/openai": ["@langchain/openai@0.5.18", "", { "dependencies": { "js-tiktoken": "^1.0.12", "openai": "^5.3.0", "zod": "^3.25.32" }, "peerDependencies": { "@langchain/core": ">=0.3.58 <0.4.0" } }, "sha512-CX1kOTbT5xVFNdtLjnM0GIYNf+P7oMSu+dGCFxxWRa3dZwWiuyuBXCm+dToUGxDLnsHuV1bKBtIzrY1mLq/A1Q=="],
 
     "@lukeed/csprng": ["@lukeed/csprng@1.1.0", "", {}, "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA=="],
@@ -84,11 +91,15 @@
 
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
@@ -229,6 +240,8 @@
     "ioredis": ["ioredis@5.10.1", "", { "dependencies": { "@ioredis/commands": "1.5.1", "cluster-key-slot": "^1.1.0", "debug": "^4.3.4", "denque": "^2.1.0", "lodash.defaults": "^4.2.0", "lodash.isarguments": "^3.1.0", "redis-errors": "^1.2.0", "redis-parser": "^3.0.0", "standard-as-callback": "^2.1.0" } }, "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-network-error": ["is-network-error@1.3.1", "", {}, "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw=="],
 
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
@@ -428,6 +441,12 @@
 
     "@langchain/core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
+    "@langchain/langgraph-sdk/p-queue": ["p-queue@9.1.2", "", { "dependencies": { "eventemitter3": "^5.0.1", "p-timeout": "^7.0.0" } }, "sha512-ktsDOALzTYTWWF1PbkNVg2rOt+HaOaMWJMUnt7T3qf5tvZ1L8dBW3tObzprBcXNMKkwj+yFSLqHso0x+UFcJXw=="],
+
+    "@langchain/langgraph-sdk/p-retry": ["p-retry@7.1.1", "", { "dependencies": { "is-network-error": "^1.1.0" } }, "sha512-J5ApzjyRkkf601HpEeykoiCvzHQjWxPAHhyjFcEUP2SWq0+35NKh8TLhpLw+Dkq5TZBFvUM6UigdE9hIVYTl5w=="],
+
+    "@langchain/langgraph-sdk/uuid": ["uuid@13.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
+
     "@langchain/openai/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "bullmq/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
@@ -435,6 +454,10 @@
     "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "multer/type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
+
+    "@langchain/langgraph-sdk/p-queue/eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "@langchain/langgraph-sdk/p-queue/p-timeout": ["p-timeout@7.0.1", "", {}, "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg=="],
 
     "multer/type-is/media-typer": ["media-typer@0.3.0", "", {}, "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="],
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@langchain/core": "^0.3.0",
+    "@langchain/langgraph": "^1.2.8",
     "@langchain/openai": "^0.5.0",
     "@nestjs/common": "11.1.18",
     "@nestjs/core": "11.1.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x-reporter",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "description": "Per-user X likes/bookmarks digest service (Bun + NestJS)",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,7 @@ import { AuthModule } from './auth/auth.module';
 import { LoggerModule } from './common/logger';
 import { loadEnv } from './config/env';
 import { HealthModule } from './health/health.module';
+import { DigestGraphModule } from './digest/graph/digest-graph.module';
 import { LlmModule } from './digest/llm/llm.module';
 import { ExtractionModule } from './extraction/extraction.module';
 import { IngestionModule } from './ingestion/ingestion.module';
@@ -70,6 +71,7 @@ export class AppModule {
         ExtractionModule.forRoot(env),
         WorkersModule.forRoot(env),
         LlmModule.forRoot(env),
+        DigestGraphModule,
       ],
     };
   }

--- a/src/digest/graph/digest-graph.module.ts
+++ b/src/digest/graph/digest-graph.module.ts
@@ -1,0 +1,25 @@
+/**
+ * NestJS wiring for `DigestGraph`.
+ *
+ * Declared `@Global()` so feature modules (notably the #11 `build-digest`
+ * processor) can inject `DigestGraph` without re-importing this module.
+ * The graph itself is a thin façade over LangGraph; the real provider
+ * composition happens inside `DigestGraph` via the injected `LlmProvider`.
+ */
+import { Global, Module } from '@nestjs/common';
+import type { LlmProvider } from '../llm/llm-provider.interface';
+import { LLM_PROVIDER } from '../llm/llm.tokens';
+import { DigestGraph } from './digest.graph';
+
+@Global()
+@Module({
+  providers: [
+    {
+      provide: DigestGraph,
+      inject: [LLM_PROVIDER],
+      useFactory: (llm: LlmProvider) => new DigestGraph(llm),
+    },
+  ],
+  exports: [DigestGraph],
+})
+export class DigestGraphModule {}

--- a/src/digest/graph/digest-state.ts
+++ b/src/digest/graph/digest-state.ts
@@ -1,0 +1,96 @@
+/**
+ * LangGraph state definition for the digest pipeline.
+ *
+ * The `DigestState` Annotation is the single source of truth for the shape
+ * flowing through the graph. Each node returns a `Partial<DigestState>` and
+ * the annotation's reducers fold those updates into the running state.
+ *
+ * Only the `usage` channel has a custom reducer — every node that calls the
+ * `LlmProvider` adds its `tokensIn`/`tokensOut` contribution and the reducer
+ * sums them so the final state carries a running total. All other channels
+ * use the default "last write wins" semantics, which matches the linear
+ * `cluster → summarize → rank → compose` edge layout.
+ *
+ * See `docs/llm-and-graph.md` for field-level semantics.
+ */
+import { Annotation } from '@langchain/langgraph';
+
+export interface EnrichedItem {
+  id: string;
+  text: string;
+  authorHandle: string;
+  kind: 'like' | 'bookmark';
+  articles: {
+    title?: string;
+    siteName?: string;
+    url: string;
+    content: string;
+  }[];
+}
+
+export interface Cluster {
+  topic: string;
+  itemIds: string[];
+}
+
+export interface ClusterSummary {
+  topic: string;
+  itemIds: string[];
+  summary: string;
+  highlights: string[];
+  score?: number;
+}
+
+export interface TokenUsage {
+  tokensIn: number;
+  tokensOut: number;
+}
+
+export interface DigestWindow {
+  start: Date;
+  end: Date;
+}
+
+/**
+ * Summing reducer for `usage`. The default starting value is zero so the
+ * graph never observes `undefined` tokens.
+ */
+function addUsage(left: TokenUsage, right: TokenUsage): TokenUsage {
+  return {
+    tokensIn: left.tokensIn + right.tokensIn,
+    tokensOut: left.tokensOut + right.tokensOut,
+  };
+}
+
+/**
+ * Reducer that concatenates per-cluster summaries produced by the
+ * `summarize` fanout. Each invocation of the summarize node returns a
+ * one-element array, so the reducer simply appends them.
+ */
+function appendSummaries(
+  left: ClusterSummary[] | undefined,
+  right: ClusterSummary[] | undefined,
+): ClusterSummary[] {
+  return [...(left ?? []), ...(right ?? [])];
+}
+
+export const DigestStateAnnotation = Annotation.Root({
+  userId: Annotation<string>(),
+  window: Annotation<DigestWindow>(),
+  items: Annotation<EnrichedItem[]>(),
+  model: Annotation<string>(),
+  clusters: Annotation<Cluster[] | undefined>(),
+  summaries: Annotation<ClusterSummary[] | undefined>({
+    reducer: appendSummaries,
+    default: () => [],
+  }),
+  ranked: Annotation<ClusterSummary[] | undefined>(),
+  markdown: Annotation<string | undefined>(),
+  usage: Annotation<TokenUsage>({
+    reducer: addUsage,
+    default: () => ({ tokensIn: 0, tokensOut: 0 }),
+  }),
+});
+
+export type DigestState = typeof DigestStateAnnotation.State;
+export type DigestStateUpdate = typeof DigestStateAnnotation.Update;

--- a/src/digest/graph/digest-state.ts
+++ b/src/digest/graph/digest-state.ts
@@ -29,11 +29,15 @@ export interface EnrichedItem {
 }
 
 export interface Cluster {
+  /** Stable identifier assigned by the cluster node (e.g. position-based). */
+  id: string;
   topic: string;
   itemIds: string[];
 }
 
 export interface ClusterSummary {
+  /** Stable identifier copied from the source `Cluster`. */
+  id: string;
   topic: string;
   itemIds: string[];
   summary: string;

--- a/src/digest/graph/digest.graph.test.ts
+++ b/src/digest/graph/digest.graph.test.ts
@@ -65,7 +65,7 @@ describe('DigestGraph', () => {
           respond: () =>
             JSON.stringify({
               summary: 'LangGraph 1.0 landed with a new annotation API.',
-              highlights: ['Revamped state', 'Send fanout'],
+              highlights: ['Revamped state', 'Send fanout', 'Reducers'],
             }),
           usage: { tokensIn: 40, tokensOut: 15 },
         },
@@ -75,7 +75,7 @@ describe('DigestGraph', () => {
           respond: () =>
             JSON.stringify({
               summary: 'Bun 1.3 and NestJS 11 both push the runtime frontier.',
-              highlights: ['Bun Node compat', 'Nest DI perf'],
+              highlights: ['Bun Node compat', 'Nest DI perf', 'Perf gains'],
             }),
           usage: { tokensIn: 45, tokensOut: 18 },
         },
@@ -85,8 +85,8 @@ describe('DigestGraph', () => {
           respond: () =>
             JSON.stringify({
               scores: [
-                { topic: 'LangGraph', score: 9 },
-                { topic: 'Runtimes', score: 6 },
+                { id: 'c0', score: 9 },
+                { id: 'c1', score: 6 },
               ],
             }),
           usage: { tokensIn: 30, tokensOut: 12 },
@@ -136,12 +136,18 @@ describe('DigestGraph', () => {
         {
           match: (opts) => opts.messages[0]?.content.includes('Topic: Primary') ?? false,
           respond: () =>
-            JSON.stringify({ summary: 'Primary cluster.', highlights: ['point'] }),
+            JSON.stringify({
+              summary: 'Primary cluster.',
+              highlights: ['point a', 'point b', 'point c'],
+            }),
         },
         {
           match: (opts) => opts.messages[0]?.content.includes('Topic: Misc') ?? false,
           respond: () =>
-            JSON.stringify({ summary: 'Misc cluster.', highlights: ['leftover'] }),
+            JSON.stringify({
+              summary: 'Misc cluster.',
+              highlights: ['leftover a', 'leftover b', 'leftover c'],
+            }),
         },
         {
           match: (opts) =>
@@ -149,15 +155,26 @@ describe('DigestGraph', () => {
           respond: () =>
             JSON.stringify({
               scores: [
-                { topic: 'Primary', score: 8 },
-                { topic: 'Misc', score: 3 },
+                { id: 'c0', score: 8 },
+                { id: 'c1', score: 3 },
               ],
             }),
         },
         {
+          // Compose stub echoes back cluster topics from its input so we can
+          // prove the Misc cluster actually reaches the final digest rather
+          // than being filtered out somewhere upstream.
           match: (opts) =>
             opts.messages[0]?.content.includes('Compose a personalized digest') ?? false,
-          respond: () => '## Primary\n\nPrimary cluster.\n',
+          respond: (opts) => {
+            const prompt = opts.messages[0]?.content ?? '';
+            const topics: string[] = [];
+            for (const match of prompt.matchAll(/###\s+\d+\.\s+([^\n(]+?)\s*\(/g)) {
+              const topic = match[1];
+              if (topic) topics.push(topic.trim());
+            }
+            return topics.map((t) => `## ${t}\n\n${t} body.\n`).join('\n');
+          },
         },
       ],
     });
@@ -170,6 +187,8 @@ describe('DigestGraph', () => {
     });
 
     expect(result.markdown).toContain('## Primary');
+    expect(result.markdown).toContain('## Misc');
+    expect(result.markdown).toContain('Misc body.');
     // cluster + 2 summarize + rank + compose = 5
     expect(stub.calls).toHaveLength(5);
   });

--- a/src/digest/graph/digest.graph.test.ts
+++ b/src/digest/graph/digest.graph.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'bun:test';
+import { DigestGraph } from './digest.graph';
+import type { EnrichedItem } from './digest-state';
+import { StubLlmProvider } from './stub-llm-provider';
+
+function makeItems(): EnrichedItem[] {
+  return [
+    {
+      id: 'i1',
+      text: 'LangGraph 1.0 released with new Annotation API.',
+      authorHandle: 'alice',
+      kind: 'like',
+      articles: [
+        {
+          title: 'LangGraph 1.0',
+          siteName: 'LangChain',
+          url: 'https://example.com/langgraph-1',
+          content: 'LangGraph 1.0 adds a revamped state annotation system.',
+        },
+      ],
+    },
+    {
+      id: 'i2',
+      text: 'Bun 1.3 ships faster Node compat.',
+      authorHandle: 'bob',
+      kind: 'bookmark',
+      articles: [
+        {
+          url: 'https://example.com/bun-1-3',
+          content: 'Bun 1.3 closes more Node.js compatibility gaps.',
+        },
+      ],
+    },
+    {
+      id: 'i3',
+      text: 'NestJS 11 improves DI performance.',
+      authorHandle: 'carol',
+      kind: 'like',
+      articles: [],
+    },
+  ];
+}
+
+describe('DigestGraph', () => {
+  it('runs the full cluster → summarize → rank → compose pipeline', async () => {
+    const stub = new StubLlmProvider({
+      model: 'stub/test',
+      defaultUsage: { tokensIn: 10, tokensOut: 20 },
+      handlers: [
+        {
+          match: (opts) =>
+            opts.messages[0]?.content.includes('Group the following items into 3–7') ?? false,
+          respond: () =>
+            JSON.stringify({
+              clusters: [
+                { topic: 'LangGraph', itemIds: ['i1'] },
+                { topic: 'Runtimes', itemIds: ['i2', 'i3'] },
+              ],
+            }),
+          usage: { tokensIn: 100, tokensOut: 50 },
+        },
+        {
+          match: (opts) =>
+            opts.messages[0]?.content.includes('Topic: LangGraph') ?? false,
+          respond: () =>
+            JSON.stringify({
+              summary: 'LangGraph 1.0 landed with a new annotation API.',
+              highlights: ['Revamped state', 'Send fanout'],
+            }),
+          usage: { tokensIn: 40, tokensOut: 15 },
+        },
+        {
+          match: (opts) =>
+            opts.messages[0]?.content.includes('Topic: Runtimes') ?? false,
+          respond: () =>
+            JSON.stringify({
+              summary: 'Bun 1.3 and NestJS 11 both push the runtime frontier.',
+              highlights: ['Bun Node compat', 'Nest DI perf'],
+            }),
+          usage: { tokensIn: 45, tokensOut: 18 },
+        },
+        {
+          match: (opts) =>
+            opts.messages[0]?.content.includes('Score each cluster from 1 to 10') ?? false,
+          respond: () =>
+            JSON.stringify({
+              scores: [
+                { topic: 'LangGraph', score: 9 },
+                { topic: 'Runtimes', score: 6 },
+              ],
+            }),
+          usage: { tokensIn: 30, tokensOut: 12 },
+        },
+        {
+          match: (opts) =>
+            opts.messages[0]?.content.includes('Compose a personalized digest') ?? false,
+          respond: () =>
+            '## LangGraph\n\nLangGraph 1.0 landed.\n\n- Revamped state\n\n### Sources\n- https://example.com/langgraph-1\n',
+          usage: { tokensIn: 60, tokensOut: 80 },
+        },
+      ],
+    });
+
+    const graph = new DigestGraph(stub);
+    const result = await graph.run({
+      userId: 'user-123',
+      window: { start: new Date('2026-04-12'), end: new Date('2026-04-13') },
+      items: makeItems(),
+    });
+
+    expect(result.markdown).toContain('## LangGraph');
+    expect(result.markdown).toContain('https://example.com/langgraph-1');
+    expect(result.itemIds).toEqual(['i1', 'i2', 'i3']);
+    expect(result.model).toBe('stub/test');
+
+    // Usage accumulates across: cluster(1) + summarize(2) + rank(1) + compose(1) = 5 calls
+    expect(stub.calls).toHaveLength(5);
+    // tokensIn: 100 + 40 + 45 + 30 + 60 = 275
+    // tokensOut: 50 + 15 + 18 + 12 + 80 = 175
+    expect(result.usage.tokensIn).toBe(275);
+    expect(result.usage.tokensOut).toBe(175);
+  });
+
+  it('sweeps unassigned items into a Misc cluster', async () => {
+    const stub = new StubLlmProvider({
+      handlers: [
+        {
+          match: (opts) =>
+            opts.messages[0]?.content.includes('Group the following items') ?? false,
+          // Leave i3 unassigned; it should land in Misc.
+          respond: () =>
+            JSON.stringify({
+              clusters: [{ topic: 'Primary', itemIds: ['i1', 'i2'] }],
+            }),
+        },
+        {
+          match: (opts) => opts.messages[0]?.content.includes('Topic: Primary') ?? false,
+          respond: () =>
+            JSON.stringify({ summary: 'Primary cluster.', highlights: ['point'] }),
+        },
+        {
+          match: (opts) => opts.messages[0]?.content.includes('Topic: Misc') ?? false,
+          respond: () =>
+            JSON.stringify({ summary: 'Misc cluster.', highlights: ['leftover'] }),
+        },
+        {
+          match: (opts) =>
+            opts.messages[0]?.content.includes('Score each cluster') ?? false,
+          respond: () =>
+            JSON.stringify({
+              scores: [
+                { topic: 'Primary', score: 8 },
+                { topic: 'Misc', score: 3 },
+              ],
+            }),
+        },
+        {
+          match: (opts) =>
+            opts.messages[0]?.content.includes('Compose a personalized digest') ?? false,
+          respond: () => '## Primary\n\nPrimary cluster.\n',
+        },
+      ],
+    });
+
+    const graph = new DigestGraph(stub);
+    const result = await graph.run({
+      userId: 'u',
+      window: { start: new Date(), end: new Date() },
+      items: makeItems(),
+    });
+
+    expect(result.markdown).toContain('## Primary');
+    // cluster + 2 summarize + rank + compose = 5
+    expect(stub.calls).toHaveLength(5);
+  });
+});

--- a/src/digest/graph/digest.graph.ts
+++ b/src/digest/graph/digest.graph.ts
@@ -39,46 +39,53 @@ export interface DigestResult {
 
 /**
  * Router that turns the cluster list into a parallel summarize fanout.
- * Returning `END` directly when there are no clusters lets the graph
- * short-circuit to `rank` (which also handles the empty case).
+ * Each `Send` carries only the items belonging to that cluster (looked up
+ * by id) so we don't pay O(N*M) memory across the fanout. Returning `rank`
+ * directly when there are no clusters lets the graph short-circuit.
  */
 function routeClustersToSummarize(state: DigestState): Send[] | 'rank' {
   const clusters = state.clusters ?? [];
   if (clusters.length === 0) return 'rank';
+  const itemsById = new Map(state.items.map((i) => [i.id, i]));
   return clusters.map(
     (cluster) =>
       new Send('summarize', {
         cluster,
-        items: state.items,
+        items: cluster.itemIds
+          .map((id) => itemsById.get(id))
+          .filter((i): i is (typeof state.items)[number] => i !== undefined),
       } satisfies SummarizePayload),
   );
 }
 
+function buildCompiledGraph(llm: LlmProvider) {
+  const clusterNode = makeClusterNode(llm);
+  const summarizeNode = makeSummarizeNode(llm);
+  const rankNode = makeRankNode(llm);
+  const composeNode = makeComposeNode(llm);
+
+  return new StateGraph(DigestStateAnnotation)
+    .addNode('cluster', clusterNode)
+    .addNode('summarize', summarizeNode)
+    .addNode('rank', rankNode)
+    .addNode('compose', composeNode)
+    .addEdge(START, 'cluster')
+    .addConditionalEdges('cluster', routeClustersToSummarize, ['summarize', 'rank'])
+    .addEdge('summarize', 'rank')
+    .addEdge('rank', 'compose')
+    .addEdge('compose', END)
+    .compile();
+}
+
 export class DigestGraph {
-  constructor(private readonly llm: LlmProvider) {}
+  private readonly app: ReturnType<typeof buildCompiledGraph>;
 
-  private build() {
-    const clusterNode = makeClusterNode(this.llm);
-    const summarizeNode = makeSummarizeNode(this.llm);
-    const rankNode = makeRankNode(this.llm);
-    const composeNode = makeComposeNode(this.llm);
-
-    return new StateGraph(DigestStateAnnotation)
-      .addNode('cluster', clusterNode)
-      .addNode('summarize', summarizeNode)
-      .addNode('rank', rankNode)
-      .addNode('compose', composeNode)
-      .addEdge(START, 'cluster')
-      .addConditionalEdges('cluster', routeClustersToSummarize, ['summarize', 'rank'])
-      .addEdge('summarize', 'rank')
-      .addEdge('rank', 'compose')
-      .addEdge('compose', END)
-      .compile();
+  constructor(private readonly llm: LlmProvider) {
+    this.app = buildCompiledGraph(llm);
   }
 
   async run(input: DigestInput): Promise<DigestResult> {
-    const app = this.build();
-    const final = (await app.invoke({
+    const final = (await this.app.invoke({
       userId: input.userId,
       window: input.window,
       items: input.items,

--- a/src/digest/graph/digest.graph.ts
+++ b/src/digest/graph/digest.graph.ts
@@ -1,0 +1,95 @@
+/**
+ * LangGraph `DigestGraph` — orchestrates the four digest nodes.
+ *
+ * Public API is intentionally narrow: callers hand `DigestGraph` a list of
+ * `EnrichedItem`s and get back `{ markdown, itemIds, usage }`. The LangGraph
+ * types never cross this boundary; if we swap orchestrators later, the
+ * processor in #11 doesn't change.
+ *
+ * Fanout: after `cluster` completes, a conditional edge emits one `Send`
+ * per cluster targeting the `summarize` node. LangGraph runs those in
+ * parallel and the `summaries` reducer concatenates the results before the
+ * graph moves on to `rank`.
+ */
+import { END, START, Send, StateGraph } from '@langchain/langgraph';
+import type { LlmProvider } from '../llm/llm-provider.interface';
+import {
+  type DigestState,
+  DigestStateAnnotation,
+  type EnrichedItem,
+  type TokenUsage,
+} from './digest-state';
+import { makeClusterNode } from './nodes/cluster.node';
+import { makeComposeNode } from './nodes/compose.node';
+import { makeRankNode } from './nodes/rank.node';
+import { type SummarizePayload, makeSummarizeNode } from './nodes/summarize.node';
+
+export interface DigestInput {
+  userId: string;
+  window: { start: Date; end: Date };
+  items: EnrichedItem[];
+}
+
+export interface DigestResult {
+  markdown: string;
+  itemIds: string[];
+  usage: TokenUsage;
+  model: string;
+}
+
+/**
+ * Router that turns the cluster list into a parallel summarize fanout.
+ * Returning `END` directly when there are no clusters lets the graph
+ * short-circuit to `rank` (which also handles the empty case).
+ */
+function routeClustersToSummarize(state: DigestState): Send[] | 'rank' {
+  const clusters = state.clusters ?? [];
+  if (clusters.length === 0) return 'rank';
+  return clusters.map(
+    (cluster) =>
+      new Send('summarize', {
+        cluster,
+        items: state.items,
+      } satisfies SummarizePayload),
+  );
+}
+
+export class DigestGraph {
+  constructor(private readonly llm: LlmProvider) {}
+
+  private build() {
+    const clusterNode = makeClusterNode(this.llm);
+    const summarizeNode = makeSummarizeNode(this.llm);
+    const rankNode = makeRankNode(this.llm);
+    const composeNode = makeComposeNode(this.llm);
+
+    return new StateGraph(DigestStateAnnotation)
+      .addNode('cluster', clusterNode)
+      .addNode('summarize', summarizeNode)
+      .addNode('rank', rankNode)
+      .addNode('compose', composeNode)
+      .addEdge(START, 'cluster')
+      .addConditionalEdges('cluster', routeClustersToSummarize, ['summarize', 'rank'])
+      .addEdge('summarize', 'rank')
+      .addEdge('rank', 'compose')
+      .addEdge('compose', END)
+      .compile();
+  }
+
+  async run(input: DigestInput): Promise<DigestResult> {
+    const app = this.build();
+    const final = (await app.invoke({
+      userId: input.userId,
+      window: input.window,
+      items: input.items,
+      model: this.llm.model,
+    })) as DigestState;
+
+    return {
+      markdown: final.markdown ?? '',
+      itemIds: input.items.map((i) => i.id),
+      usage: final.usage,
+      model: this.llm.model,
+    };
+  }
+}

--- a/src/digest/graph/nodes/cluster.node.ts
+++ b/src/digest/graph/nodes/cluster.node.ts
@@ -32,8 +32,11 @@ const ClusterSchema = z.object({
   itemIds: z.array(z.string()).min(1),
 });
 
+// Note: we intentionally do not require a non-empty array here — if the LLM
+// returns no clusters, `reconcileClusters` sweeps everything into a single
+// `Misc` cluster so downstream nodes always have at least one group to work on.
 const ClusterResponseSchema = z.object({
-  clusters: z.array(ClusterSchema).min(1),
+  clusters: z.array(ClusterSchema),
 });
 
 function formatItems(items: EnrichedItem[]): string {
@@ -51,7 +54,10 @@ function formatItems(items: EnrichedItem[]): string {
  *   - sweep unassigned ids into a trailing `Misc` cluster
  *   - drop clusters that end up empty after dedup
  */
-function reconcileClusters(raw: Cluster[], items: EnrichedItem[]): Cluster[] {
+function reconcileClusters(
+  raw: Array<{ topic: string; itemIds: string[] }>,
+  items: EnrichedItem[],
+): Cluster[] {
   const assigned = new Set<string>();
   const knownIds = new Set(items.map((i) => i.id));
   const reconciled: Cluster[] = [];
@@ -65,7 +71,11 @@ function reconcileClusters(raw: Cluster[], items: EnrichedItem[]): Cluster[] {
       uniqueIds.push(id);
     }
     if (uniqueIds.length > 0) {
-      reconciled.push({ topic: c.topic, itemIds: uniqueIds });
+      reconciled.push({
+        id: `c${reconciled.length}`,
+        topic: c.topic,
+        itemIds: uniqueIds,
+      });
     }
   }
 
@@ -74,7 +84,11 @@ function reconcileClusters(raw: Cluster[], items: EnrichedItem[]): Cluster[] {
     if (!assigned.has(it.id)) leftovers.push(it.id);
   }
   if (leftovers.length > 0) {
-    reconciled.push({ topic: 'Misc', itemIds: leftovers });
+    reconciled.push({
+      id: `c${reconciled.length}`,
+      topic: 'Misc',
+      itemIds: leftovers,
+    });
   }
 
   return reconciled;

--- a/src/digest/graph/nodes/cluster.node.ts
+++ b/src/digest/graph/nodes/cluster.node.ts
@@ -1,0 +1,105 @@
+/**
+ * `cluster` node: asks the LLM to group items into 3–7 topic clusters.
+ *
+ * One LLM call. JSON response validated with zod; any item missing from the
+ * model's output is swept into a single `Misc` cluster so downstream nodes
+ * can assume every `EnrichedItem.id` appears in exactly one cluster.
+ * Duplicate assignments resolve to the first occurrence.
+ */
+import { z } from 'zod';
+import type { LlmProvider } from '../../llm/llm-provider.interface';
+import type { Cluster, DigestState, DigestStateUpdate, EnrichedItem } from '../digest-state';
+
+export const CLUSTER_SYSTEM_PROMPT =
+  'You are an editorial assistant that groups social items into coherent topic clusters. Respond with JSON only.';
+
+export const CLUSTER_USER_PROMPT = `Group the following items into 3–7 coherent topic clusters.
+Each cluster has a short human-readable label and the list of item IDs that belong to it.
+Every item id must appear in exactly one cluster. Prefer fewer clusters when items overlap.
+
+Return JSON of the form:
+{
+  "clusters": [
+    { "topic": "short label", "itemIds": ["id1", "id2"] }
+  ]
+}
+
+Items:
+`;
+
+const ClusterSchema = z.object({
+  topic: z.string().min(1),
+  itemIds: z.array(z.string()).min(1),
+});
+
+const ClusterResponseSchema = z.object({
+  clusters: z.array(ClusterSchema).min(1),
+});
+
+function formatItems(items: EnrichedItem[]): string {
+  return items
+    .map((it) => {
+      const text = it.text.replace(/\s+/g, ' ').trim();
+      return `- id=${it.id} @${it.authorHandle} [${it.kind}]: ${text}`;
+    })
+    .join('\n');
+}
+
+/**
+ * Fold LLM output back into a deterministic cluster list:
+ *   - keep the first cluster that claims each id (drop duplicates silently)
+ *   - sweep unassigned ids into a trailing `Misc` cluster
+ *   - drop clusters that end up empty after dedup
+ */
+function reconcileClusters(raw: Cluster[], items: EnrichedItem[]): Cluster[] {
+  const assigned = new Set<string>();
+  const knownIds = new Set(items.map((i) => i.id));
+  const reconciled: Cluster[] = [];
+
+  for (const c of raw) {
+    const uniqueIds: string[] = [];
+    for (const id of c.itemIds) {
+      if (!knownIds.has(id)) continue;
+      if (assigned.has(id)) continue;
+      assigned.add(id);
+      uniqueIds.push(id);
+    }
+    if (uniqueIds.length > 0) {
+      reconciled.push({ topic: c.topic, itemIds: uniqueIds });
+    }
+  }
+
+  const leftovers: string[] = [];
+  for (const it of items) {
+    if (!assigned.has(it.id)) leftovers.push(it.id);
+  }
+  if (leftovers.length > 0) {
+    reconciled.push({ topic: 'Misc', itemIds: leftovers });
+  }
+
+  return reconciled;
+}
+
+export function makeClusterNode(llm: LlmProvider) {
+  return async function clusterNode(state: DigestState): Promise<DigestStateUpdate> {
+    const result = await llm.chat({
+      system: CLUSTER_SYSTEM_PROMPT,
+      messages: [
+        {
+          role: 'user',
+          content: CLUSTER_USER_PROMPT + formatItems(state.items),
+        },
+      ],
+      responseFormat: 'json',
+      temperature: 0.2,
+    });
+
+    const parsed = ClusterResponseSchema.parse(JSON.parse(result.content));
+    const clusters = reconcileClusters(parsed.clusters, state.items);
+
+    return {
+      clusters,
+      usage: result.usage,
+    };
+  };
+}

--- a/src/digest/graph/nodes/compose.node.ts
+++ b/src/digest/graph/nodes/compose.node.ts
@@ -1,0 +1,62 @@
+/**
+ * `compose` node: a single LLM call that renders the ranked summaries into
+ * the final markdown digest. No validation schema — the output is free-form
+ * markdown rather than JSON — but a zod check guards against empty strings.
+ */
+import { z } from 'zod';
+import type { LlmProvider } from '../../llm/llm-provider.interface';
+import type { ClusterSummary, DigestState, DigestStateUpdate } from '../digest-state';
+
+export const COMPOSE_SYSTEM_PROMPT =
+  'You are an editorial assistant that composes personalized markdown digests. Write tight, scannable prose.';
+
+export const COMPOSE_USER_PROMPT_PREFIX = `Compose a personalized digest in markdown using the ranked clusters below.
+
+Formatting rules:
+- Start with the highest-ranked cluster.
+- Each cluster gets an "##" header using its topic label.
+- Follow each header with the synthesis paragraph, then the bullet highlights as a "-" list.
+- End each section with a "Sources" sub-list of the article URLs (use raw links).
+- Keep it tight — no filler intro or outro.
+
+Clusters:
+`;
+
+const MarkdownSchema = z.string().min(1);
+
+function formatRankedForPrompt(ranked: ClusterSummary[]): string {
+  return ranked
+    .map((s, i) => {
+      const highlights = s.highlights.map((h) => `  - ${h}`).join('\n');
+      return `### ${i + 1}. ${s.topic} (score=${s.score ?? 0})\n${s.summary}\nHighlights:\n${highlights}\nItem IDs: ${s.itemIds.join(', ')}`;
+    })
+    .join('\n\n');
+}
+
+export function makeComposeNode(llm: LlmProvider) {
+  return async function composeNode(state: DigestState): Promise<DigestStateUpdate> {
+    const ranked = state.ranked ?? [];
+    if (ranked.length === 0) {
+      return { markdown: '' };
+    }
+
+    const result = await llm.chat({
+      system: COMPOSE_SYSTEM_PROMPT,
+      messages: [
+        {
+          role: 'user',
+          content: COMPOSE_USER_PROMPT_PREFIX + formatRankedForPrompt(ranked),
+        },
+      ],
+      responseFormat: 'text',
+      temperature: 0.4,
+    });
+
+    const markdown = MarkdownSchema.parse(result.content.trim());
+
+    return {
+      markdown,
+      usage: result.usage,
+    };
+  };
+}

--- a/src/digest/graph/nodes/compose.node.ts
+++ b/src/digest/graph/nodes/compose.node.ts
@@ -5,7 +5,12 @@
  */
 import { z } from 'zod';
 import type { LlmProvider } from '../../llm/llm-provider.interface';
-import type { ClusterSummary, DigestState, DigestStateUpdate } from '../digest-state';
+import type {
+  ClusterSummary,
+  DigestState,
+  DigestStateUpdate,
+  EnrichedItem,
+} from '../digest-state';
 
 export const COMPOSE_SYSTEM_PROMPT =
   'You are an editorial assistant that composes personalized markdown digests. Write tight, scannable prose.';
@@ -16,7 +21,7 @@ Formatting rules:
 - Start with the highest-ranked cluster.
 - Each cluster gets an "##" header using its topic label.
 - Follow each header with the synthesis paragraph, then the bullet highlights as a "-" list.
-- End each section with a "Sources" sub-list of the article URLs (use raw links).
+- End each section with a "Sources" sub-list containing ONLY the URLs listed under that cluster's "Sources:" block below (use raw links, do not invent URLs).
 - Keep it tight — no filler intro or outro.
 
 Clusters:
@@ -24,11 +29,31 @@ Clusters:
 
 const MarkdownSchema = z.string().min(1);
 
-function formatRankedForPrompt(ranked: ClusterSummary[]): string {
+function collectUrls(itemIds: string[], items: EnrichedItem[]): string[] {
+  const idSet = new Set(itemIds);
+  const urls: string[] = [];
+  const seen = new Set<string>();
+  for (const item of items) {
+    if (!idSet.has(item.id)) continue;
+    for (const article of item.articles) {
+      if (seen.has(article.url)) continue;
+      seen.add(article.url);
+      urls.push(article.url);
+    }
+  }
+  return urls;
+}
+
+function formatRankedForPrompt(ranked: ClusterSummary[], items: EnrichedItem[]): string {
   return ranked
     .map((s, i) => {
       const highlights = s.highlights.map((h) => `  - ${h}`).join('\n');
-      return `### ${i + 1}. ${s.topic} (score=${s.score ?? 0})\n${s.summary}\nHighlights:\n${highlights}\nItem IDs: ${s.itemIds.join(', ')}`;
+      const urls = collectUrls(s.itemIds, items);
+      const sources =
+        urls.length > 0
+          ? `Sources:\n${urls.map((u) => `  - ${u}`).join('\n')}`
+          : 'Sources: (none)';
+      return `### ${i + 1}. ${s.topic} (score=${s.score ?? 0})\n${s.summary}\nHighlights:\n${highlights}\n${sources}`;
     })
     .join('\n\n');
 }
@@ -45,7 +70,7 @@ export function makeComposeNode(llm: LlmProvider) {
       messages: [
         {
           role: 'user',
-          content: COMPOSE_USER_PROMPT_PREFIX + formatRankedForPrompt(ranked),
+          content: COMPOSE_USER_PROMPT_PREFIX + formatRankedForPrompt(ranked, state.items),
         },
       ],
       responseFormat: 'text',

--- a/src/digest/graph/nodes/rank.node.ts
+++ b/src/digest/graph/nodes/rank.node.ts
@@ -1,0 +1,74 @@
+/**
+ * `rank` node: a single LLM call that scores each cluster 1–10 for
+ * newsworthiness and signal density. Output is sorted descending by score
+ * and surfaced as `state.ranked`.
+ *
+ * Clusters that the LLM omits are ranked last with `score = 0` so no
+ * summary is silently dropped.
+ */
+import { z } from 'zod';
+import type { LlmProvider } from '../../llm/llm-provider.interface';
+import type { ClusterSummary, DigestState, DigestStateUpdate } from '../digest-state';
+
+export const RANK_SYSTEM_PROMPT =
+  'You are an editorial assistant that scores topic clusters on signal and newsworthiness for a reader whose interests are reflected in the source items. Respond with JSON only.';
+
+export const RANK_USER_PROMPT = `Score each cluster from 1 to 10 on newsworthiness and signal density.
+Higher scores mean the reader will get more value from reading it. Do not
+deduplicate or rewrite — just score.
+
+Return JSON of the form:
+{
+  "scores": [
+    { "topic": "exact topic label", "score": 8 }
+  ]
+}
+
+Clusters:
+`;
+
+const RankResponseSchema = z.object({
+  scores: z.array(z.object({ topic: z.string(), score: z.number() })),
+});
+
+function formatSummaries(summaries: ClusterSummary[]): string {
+  return summaries
+    .map((s) => `- ${s.topic}: ${s.summary}`)
+    .join('\n');
+}
+
+export function makeRankNode(llm: LlmProvider) {
+  return async function rankNode(state: DigestState): Promise<DigestStateUpdate> {
+    const summaries = state.summaries ?? [];
+    if (summaries.length === 0) {
+      return { ranked: [] };
+    }
+
+    const result = await llm.chat({
+      system: RANK_SYSTEM_PROMPT,
+      messages: [
+        {
+          role: 'user',
+          content: RANK_USER_PROMPT + formatSummaries(summaries),
+        },
+      ],
+      responseFormat: 'json',
+      temperature: 0.1,
+    });
+
+    const parsed = RankResponseSchema.parse(JSON.parse(result.content));
+    const scoreByTopic = new Map<string, number>();
+    for (const s of parsed.scores) {
+      if (!scoreByTopic.has(s.topic)) scoreByTopic.set(s.topic, s.score);
+    }
+
+    const ranked = summaries
+      .map((s) => ({ ...s, score: scoreByTopic.get(s.topic) ?? 0 }))
+      .sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
+
+    return {
+      ranked,
+      usage: result.usage,
+    };
+  };
+}

--- a/src/digest/graph/nodes/rank.node.ts
+++ b/src/digest/graph/nodes/rank.node.ts
@@ -15,12 +15,12 @@ export const RANK_SYSTEM_PROMPT =
 
 export const RANK_USER_PROMPT = `Score each cluster from 1 to 10 on newsworthiness and signal density.
 Higher scores mean the reader will get more value from reading it. Do not
-deduplicate or rewrite — just score.
+deduplicate or rewrite — just score. Echo back the exact cluster id.
 
 Return JSON of the form:
 {
   "scores": [
-    { "topic": "exact topic label", "score": 8 }
+    { "id": "c0", "score": 8 }
   ]
 }
 
@@ -28,12 +28,12 @@ Clusters:
 `;
 
 const RankResponseSchema = z.object({
-  scores: z.array(z.object({ topic: z.string(), score: z.number() })),
+  scores: z.array(z.object({ id: z.string(), score: z.number() })),
 });
 
 function formatSummaries(summaries: ClusterSummary[]): string {
   return summaries
-    .map((s) => `- ${s.topic}: ${s.summary}`)
+    .map((s) => `- id=${s.id} topic="${s.topic}": ${s.summary}`)
     .join('\n');
 }
 
@@ -57,13 +57,13 @@ export function makeRankNode(llm: LlmProvider) {
     });
 
     const parsed = RankResponseSchema.parse(JSON.parse(result.content));
-    const scoreByTopic = new Map<string, number>();
+    const scoreById = new Map<string, number>();
     for (const s of parsed.scores) {
-      if (!scoreByTopic.has(s.topic)) scoreByTopic.set(s.topic, s.score);
+      if (!scoreById.has(s.id)) scoreById.set(s.id, s.score);
     }
 
     const ranked = summaries
-      .map((s) => ({ ...s, score: scoreByTopic.get(s.topic) ?? 0 }))
+      .map((s) => ({ ...s, score: scoreById.get(s.id) ?? 0 }))
       .sort((a, b) => (b.score ?? 0) - (a.score ?? 0));
 
     return {

--- a/src/digest/graph/nodes/summarize.node.ts
+++ b/src/digest/graph/nodes/summarize.node.ts
@@ -1,0 +1,99 @@
+/**
+ * `summarize` node: one LLM call per cluster, fanned out via `Send`.
+ *
+ * The router in `digest.graph.ts` emits one `Send` per cluster carrying the
+ * cluster payload plus the item lookup it needs. Each invocation writes a
+ * single-element `summaries` array; the state reducer concatenates them.
+ *
+ * Article content is truncated to a per-item char budget so we don't blow
+ * the context window when a cluster has many long articles.
+ */
+import { z } from 'zod';
+import type { LlmProvider } from '../../llm/llm-provider.interface';
+import type {
+  Cluster,
+  ClusterSummary,
+  DigestStateUpdate,
+  EnrichedItem,
+} from '../digest-state';
+
+export const SUMMARIZE_SYSTEM_PROMPT =
+  'You are an editorial assistant that writes tight, high-signal topic summaries. Respond with JSON only.';
+
+export const SUMMARIZE_USER_PROMPT_PREFIX = `Write a 2–4 sentence synthesis of what's worth knowing about this topic cluster, plus 3–6 bullet highlights.
+Cite source URLs inline where relevant. Prefer concrete claims over vague framing.
+
+Return JSON of the form:
+{
+  "summary": "2-4 sentence paragraph",
+  "highlights": ["bullet one", "bullet two"]
+}
+
+Topic: `;
+
+export const ARTICLE_CHAR_BUDGET = 2000;
+
+export interface SummarizePayload {
+  cluster: Cluster;
+  items: EnrichedItem[];
+}
+
+const SummarizeResponseSchema = z.object({
+  summary: z.string().min(1),
+  highlights: z.array(z.string()).min(1),
+});
+
+function truncate(text: string, budget: number): string {
+  if (text.length <= budget) return text;
+  return `${text.slice(0, budget)}…`;
+}
+
+function formatClusterItems(items: EnrichedItem[]): string {
+  return items
+    .map((it) => {
+      const header = `- id=${it.id} @${it.authorHandle} [${it.kind}]: ${it.text.replace(/\s+/g, ' ').trim()}`;
+      if (it.articles.length === 0) return header;
+      const articleLines = it.articles
+        .map((a) => {
+          const title = a.title ? ` "${a.title}"` : '';
+          const site = a.siteName ? ` (${a.siteName})` : '';
+          return `    · ${a.url}${title}${site}\n      ${truncate(a.content, ARTICLE_CHAR_BUDGET).replace(/\n+/g, ' ')}`;
+        })
+        .join('\n');
+      return `${header}\n${articleLines}`;
+    })
+    .join('\n');
+}
+
+export function makeSummarizeNode(llm: LlmProvider) {
+  return async function summarizeNode(payload: SummarizePayload): Promise<DigestStateUpdate> {
+    const { cluster, items } = payload;
+    const inCluster = items.filter((i) => cluster.itemIds.includes(i.id));
+
+    const result = await llm.chat({
+      system: SUMMARIZE_SYSTEM_PROMPT,
+      messages: [
+        {
+          role: 'user',
+          content: `${SUMMARIZE_USER_PROMPT_PREFIX}${cluster.topic}\n\nItems:\n${formatClusterItems(inCluster)}`,
+        },
+      ],
+      responseFormat: 'json',
+      temperature: 0.3,
+    });
+
+    const parsed = SummarizeResponseSchema.parse(JSON.parse(result.content));
+
+    const summary: ClusterSummary = {
+      topic: cluster.topic,
+      itemIds: cluster.itemIds,
+      summary: parsed.summary,
+      highlights: parsed.highlights,
+    };
+
+    return {
+      summaries: [summary],
+      usage: result.usage,
+    };
+  };
+}

--- a/src/digest/graph/nodes/summarize.node.ts
+++ b/src/digest/graph/nodes/summarize.node.ts
@@ -2,8 +2,9 @@
  * `summarize` node: one LLM call per cluster, fanned out via `Send`.
  *
  * The router in `digest.graph.ts` emits one `Send` per cluster carrying the
- * cluster payload plus the item lookup it needs. Each invocation writes a
- * single-element `summaries` array; the state reducer concatenates them.
+ * cluster payload plus only the items belonging to that cluster. Each
+ * invocation writes a single-element `summaries` array; the state reducer
+ * concatenates them.
  *
  * Article content is truncated to a per-item char budget so we don't blow
  * the context window when a cluster has many long articles.
@@ -40,7 +41,7 @@ export interface SummarizePayload {
 
 const SummarizeResponseSchema = z.object({
   summary: z.string().min(1),
-  highlights: z.array(z.string()).min(1),
+  highlights: z.array(z.string().min(1)).min(3).max(6),
 });
 
 function truncate(text: string, budget: number): string {
@@ -68,14 +69,15 @@ function formatClusterItems(items: EnrichedItem[]): string {
 export function makeSummarizeNode(llm: LlmProvider) {
   return async function summarizeNode(payload: SummarizePayload): Promise<DigestStateUpdate> {
     const { cluster, items } = payload;
-    const inCluster = items.filter((i) => cluster.itemIds.includes(i.id));
+    // The router pre-filters `items` to this cluster's members, so no
+    // re-filtering is needed here.
 
     const result = await llm.chat({
       system: SUMMARIZE_SYSTEM_PROMPT,
       messages: [
         {
           role: 'user',
-          content: `${SUMMARIZE_USER_PROMPT_PREFIX}${cluster.topic}\n\nItems:\n${formatClusterItems(inCluster)}`,
+          content: `${SUMMARIZE_USER_PROMPT_PREFIX}${cluster.topic}\n\nItems:\n${formatClusterItems(items)}`,
         },
       ],
       responseFormat: 'json',
@@ -85,6 +87,7 @@ export function makeSummarizeNode(llm: LlmProvider) {
     const parsed = SummarizeResponseSchema.parse(JSON.parse(result.content));
 
     const summary: ClusterSummary = {
+      id: cluster.id,
       topic: cluster.topic,
       itemIds: cluster.itemIds,
       summary: parsed.summary,

--- a/src/digest/graph/stub-llm-provider.ts
+++ b/src/digest/graph/stub-llm-provider.ts
@@ -1,0 +1,56 @@
+/**
+ * Reusable `LlmProvider` stub for DigestGraph tests.
+ *
+ * Each chat() call is matched against the registered handlers in
+ * registration order. The first handler whose `match` predicate returns
+ * true wins; its `respond` function produces the content. Usage is
+ * either the constant `usage` passed to the stub or the per-handler
+ * override. Every call is recorded in `.calls` so tests can assert the
+ * exact shape of the fanout.
+ *
+ * This lives alongside the graph (rather than under `test/`) so future
+ * issues (snapshot tests, integration tests) can reuse it.
+ */
+import type {
+  ChatOptions,
+  ChatResult,
+  LlmProvider,
+} from '../llm/llm-provider.interface';
+
+export interface StubHandler {
+  match: (opts: ChatOptions) => boolean;
+  respond: (opts: ChatOptions) => string;
+  usage?: { tokensIn: number; tokensOut: number };
+}
+
+export interface StubLlmProviderOptions {
+  model?: string;
+  defaultUsage?: { tokensIn: number; tokensOut: number };
+  handlers: StubHandler[];
+}
+
+export class StubLlmProvider implements LlmProvider {
+  readonly model: string;
+  readonly calls: ChatOptions[] = [];
+  private readonly handlers: StubHandler[];
+  private readonly defaultUsage: { tokensIn: number; tokensOut: number };
+
+  constructor(opts: StubLlmProviderOptions) {
+    this.model = opts.model ?? 'stub-model';
+    this.handlers = opts.handlers;
+    this.defaultUsage = opts.defaultUsage ?? { tokensIn: 10, tokensOut: 20 };
+  }
+
+  async chat(opts: ChatOptions): Promise<ChatResult> {
+    this.calls.push(opts);
+    const handler = this.handlers.find((h) => h.match(opts));
+    if (!handler) {
+      const preview = opts.messages[0]?.content?.slice(0, 120) ?? '(no message)';
+      throw new Error(`StubLlmProvider: no handler matched. First message: ${preview}`);
+    }
+    return {
+      content: handler.respond(opts),
+      usage: handler.usage ?? this.defaultUsage,
+    };
+  }
+}

--- a/src/digest/llm/llm.module.ts
+++ b/src/digest/llm/llm.module.ts
@@ -16,6 +16,9 @@ export class LlmModule {
   static forRoot(env: Env): DynamicModule {
     return {
       module: LlmModule,
+      // `global: true` so `DigestGraphModule` (#10) and any future consumer
+      // can inject `LLM_PROVIDER` without re-importing LlmModule.
+      global: true,
       providers: [
         {
           provide: LLM_PROVIDER,


### PR DESCRIPTION
## Summary
- Adds the four-node LangGraph `StateGraph` (`cluster → summarize → rank → compose`) that drives digest assembly, with `summarize` fanning out per cluster via `Send`
- State defined via `Annotation.Root` with a summing reducer on `usage` so `tokensIn`/`tokensOut` accumulate across every `LlmProvider.chat` call; `summaries` uses an append reducer to gather the parallel fanout
- Each node lives in its own module with its prompt as a `const` and zod-validates the LLM's JSON response before use; the `cluster` node reconciles missing/duplicate ids into a trailing `Misc` bucket
- `DigestGraph.run()` is the only public surface — no LangGraph types leak to callers; `DigestGraphModule` is `@Global()` so the upcoming #11 processor can inject it without re-importing
- Reusable `StubLlmProvider` drives a full-graph unit test that asserts final `markdown`, `itemIds`, and summed `usage`

## Test plan
- [x] `bun test src/digest/graph/` — 2 tests pass (full-pipeline run + `Misc` sweep)
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx biome lint .` — clean on touched files
- [x] `bun test` — only pre-existing failures remain (`AppModule` e2e needs Redis; `IngestionModule.forRoot` is the known pre-existing fail)

Closes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global digest generation module: clustering, per-topic summarization, ranking, and final markdown composition; exposes a run API returning markdown, ordered item IDs, token usage, and model metadata.
* **Tests**
  * Added integration tests validating the full digest pipeline and edge cases (unassigned items → Misc).
* **Chores**
  * Project version bumped to 0.9.0 and a new langgraph dependency added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->