### PR TITLE
feat(workers): build-digest processor + /digests endpoints (#11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ Thumbs.db
 
 # bun
 .bun-cache/
+.worktrees/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x-reporter",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "description": "Per-user X likes/bookmarks digest service (Bun + NestJS)",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { loadEnv } from './config/env';
 import { HealthModule } from './health/health.module';
 import { DigestGraphModule } from './digest/graph/digest-graph.module';
 import { LlmModule } from './digest/llm/llm.module';
+import { DigestsModule } from './digests/digests.module';
 import { ExtractionModule } from './extraction/extraction.module';
 import { IngestionModule } from './ingestion/ingestion.module';
 import { QueueModule } from './queue/queue.module';
@@ -72,6 +73,7 @@ export class AppModule {
         WorkersModule.forRoot(env),
         LlmModule.forRoot(env),
         DigestGraphModule,
+        DigestsModule.forRoot(env),
       ],
     };
   }

--- a/src/digests/digests.controller.test.ts
+++ b/src/digests/digests.controller.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'bun:test';
+import { DigestsController } from './digests.controller';
+import type {
+  DigestDetail,
+  DigestListResponse,
+  DigestsService,
+  RunNowResult,
+} from './digests.service';
+
+/**
+ * HTTP boundary tests for `DigestsController`. Covers the acceptance
+ * criteria from issue #11:
+ *
+ *   - `GET /digests` validates the query string with a strict zod
+ *     schema and delegates to `DigestsService.list`.
+ *   - `GET /digests/:id` returns the full row when owned, 404 when
+ *     not (collapsing "missing" and "not owned" to the same status).
+ *   - `POST /digests/run-now` answers `202` with `{ jobId }`.
+ *
+ * Fakes mirror the pattern in `users.controller.test.ts`.
+ */
+
+interface FakeServiceState {
+  listCalls: Array<{ userId: string; limit: number; cursor?: string }>;
+  getCalls: Array<{ userId: string; id: string }>;
+  runCalls: string[];
+  listResult: DigestListResponse;
+  getResult: DigestDetail | null;
+  runResult: RunNowResult;
+}
+
+function makeFakeService(): {
+  service: DigestsService;
+  state: FakeServiceState;
+} {
+  const state: FakeServiceState = {
+    listCalls: [],
+    getCalls: [],
+    runCalls: [],
+    listResult: { items: [] },
+    getResult: null,
+    runResult: { jobId: 'job-1', queuedAt: '2026-04-06T00:00:00.000Z' },
+  };
+  const service: Pick<DigestsService, 'list' | 'getById' | 'enqueueRunNow'> = {
+    async list(userId, limit, cursor) {
+      const call: { userId: string; limit: number; cursor?: string } = {
+        userId,
+        limit,
+      };
+      if (cursor !== undefined) call.cursor = cursor;
+      state.listCalls.push(call);
+      return state.listResult;
+    },
+    async getById(userId, id) {
+      state.getCalls.push({ userId, id });
+      return state.getResult;
+    },
+    async enqueueRunNow(userId) {
+      state.runCalls.push(userId);
+      return state.runResult;
+    },
+  };
+  return { service: service as DigestsService, state };
+}
+
+function makeReq(userId: string | undefined): { user?: { id: string } } {
+  return userId ? { user: { id: userId } } : {};
+}
+
+describe('DigestsController GET /digests', () => {
+  it('calls the service with defaults when no query params are provided', async () => {
+    const { service, state } = makeFakeService();
+    const controller = new DigestsController(service);
+    state.listResult = { items: [] };
+    await controller.list(makeReq('u1') as never, {});
+    expect(state.listCalls).toEqual([{ userId: 'u1', limit: 20 }]);
+  });
+
+  it('forwards limit and cursor from the query string', async () => {
+    const { service, state } = makeFakeService();
+    const controller = new DigestsController(service);
+    await controller.list(makeReq('u1') as never, { limit: '5', cursor: 'd_x' });
+    expect(state.listCalls[0]).toEqual({ userId: 'u1', limit: 5, cursor: 'd_x' });
+  });
+
+  it('rejects limit <= 0 with 400 validation_failed', async () => {
+    const { service } = makeFakeService();
+    const controller = new DigestsController(service);
+    let caught: unknown;
+    try {
+      await controller.list(makeReq('u1') as never, { limit: '0' });
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as { getStatus?: () => number }).getStatus?.()).toBe(400);
+    const body = (caught as { getResponse: () => unknown }).getResponse();
+    expect(body).toMatchObject({ error: { code: 'validation_failed' } });
+  });
+
+  it('rejects unknown query keys (strict schema)', async () => {
+    const { service } = makeFakeService();
+    const controller = new DigestsController(service);
+    let caught: unknown;
+    try {
+      await controller.list(makeReq('u1') as never, { bogus: 'x' });
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as { getStatus?: () => number }).getStatus?.()).toBe(400);
+  });
+
+  it('throws 401 when req.user is missing', async () => {
+    const { service } = makeFakeService();
+    const controller = new DigestsController(service);
+    let caught: unknown;
+    try {
+      await controller.list({} as never, {});
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as { getStatus?: () => number }).getStatus?.()).toBe(401);
+  });
+});
+
+describe('DigestsController GET /digests/:id', () => {
+  it('returns the service result when owned', async () => {
+    const { service, state } = makeFakeService();
+    const controller = new DigestsController(service);
+    const row = {
+      id: 'd1',
+      userId: 'u1',
+      windowStart: '2026-04-05T00:00:00.000Z',
+      windowEnd: '2026-04-06T00:00:00.000Z',
+      markdown: '## hi',
+      itemIds: ['i1'],
+      model: 'anthropic/claude-sonnet-4.5',
+      tokensIn: 1,
+      tokensOut: 2,
+      createdAt: '2026-04-06T00:05:00.000Z',
+    };
+    state.getResult = row;
+    const result = await controller.getById(makeReq('u1') as never, 'd1');
+    expect(result).toEqual(row);
+    expect(state.getCalls).toEqual([{ userId: 'u1', id: 'd1' }]);
+  });
+
+  it('returns 404 with the documented envelope when the service returns null', async () => {
+    const { service, state } = makeFakeService();
+    const controller = new DigestsController(service);
+    state.getResult = null;
+    let caught: unknown;
+    try {
+      await controller.getById(makeReq('u1') as never, 'd_other');
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as { getStatus?: () => number }).getStatus?.()).toBe(404);
+    const body = (caught as { getResponse: () => unknown }).getResponse();
+    expect(body).toMatchObject({ error: { code: 'not_found', details: {} } });
+  });
+});
+
+describe('DigestsController POST /digests/run-now', () => {
+  it('enqueues a job and returns the job id', async () => {
+    const { service, state } = makeFakeService();
+    const controller = new DigestsController(service);
+    state.runResult = { jobId: 'job-42', queuedAt: '2026-04-06T00:00:00.000Z' };
+    const result = await controller.runNow(makeReq('u1') as never);
+    expect(state.runCalls).toEqual(['u1']);
+    expect(result).toEqual({ jobId: 'job-42', queuedAt: '2026-04-06T00:00:00.000Z' });
+  });
+
+  it('throws 401 when req.user is missing', async () => {
+    const { service } = makeFakeService();
+    const controller = new DigestsController(service);
+    let caught: unknown;
+    try {
+      await controller.runNow({} as never);
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as { getStatus?: () => number }).getStatus?.()).toBe(401);
+  });
+});

--- a/src/digests/digests.controller.ts
+++ b/src/digests/digests.controller.ts
@@ -57,6 +57,16 @@ const ListDigestsQuerySchema = z
   })
   .strict();
 
+/**
+ * zod schema for the `GET /digests/:id` path parameter. Kept here so the
+ * HTTP boundary validates external input with the same shape the service
+ * expects (non-empty string); callers passing an empty id get
+ * `400 validation_failed` rather than leaking through to the repo.
+ */
+const DigestIdParamSchema = z.object({
+  id: z.string().min(1),
+});
+
 /** Error-envelope helpers — same shape documented in `docs/api.md#errors`. */
 function validationFailedBody(details: unknown): {
   error: { code: string; message: string; details: unknown };
@@ -119,7 +129,11 @@ export class DigestsController {
     @Param('id') id: string,
   ): Promise<DigestDetail> {
     const userId = requireUserId(req);
-    const digest = await this.digests.getById(userId, id);
+    const parsed = DigestIdParamSchema.safeParse({ id });
+    if (!parsed.success) {
+      throw new BadRequestException(validationFailedBody(parsed.error.issues));
+    }
+    const digest = await this.digests.getById(userId, parsed.data.id);
     if (!digest) {
       throw new NotFoundException(notFoundBody('digest not found'));
     }

--- a/src/digests/digests.controller.ts
+++ b/src/digests/digests.controller.ts
@@ -1,0 +1,152 @@
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  HttpCode,
+  NotFoundException,
+  Param,
+  Post,
+  Query,
+  Req,
+  UnauthorizedException,
+  UseGuards,
+} from '@nestjs/common';
+import { z } from 'zod';
+import { SessionGuard } from '../common/session.guard';
+import {
+  DIGEST_LIST_DEFAULT_LIMIT,
+  DIGEST_LIST_MAX_LIMIT,
+  type DigestDetail,
+  type DigestListResponse,
+  DigestsService,
+  type RunNowResult,
+} from './digests.service';
+
+/**
+ * HTTP surface for `/digests` (issue #11).
+ *
+ *   - `GET /digests?limit&cursor` — paginated list, newest first.
+ *     Query params are validated with zod. Each row returns a
+ *     `preview` (first ~200 chars of markdown) — full markdown stays
+ *     on the detail endpoint so the list response doesn't balloon.
+ *
+ *   - `GET /digests/:id` — full digest payload. Returns `404` when
+ *     the id either doesn't exist or doesn't belong to the caller;
+ *     collapsing both cases to the same status prevents a malicious
+ *     client from probing ids owned by other users.
+ *
+ *   - `POST /digests/run-now` — enqueue a one-shot `build-digest`
+ *     job for the caller. Responds `202 Accepted` with the job id
+ *     assigned by BullMQ.
+ *
+ * All three routes are gated by `SessionGuard`, which attaches
+ * `req.user.id`. The controller is a thin HTTP translator over
+ * `DigestsService` — no repo or queue calls here.
+ */
+
+/**
+ * zod schema for the `GET /digests` query string. Both params are
+ * optional with documented defaults. `limit` is clamped by the
+ * schema; callers that exceed the maximum get `400 validation_failed`
+ * rather than a silent clamp so they notice the ceiling.
+ */
+const ListDigestsQuerySchema = z
+  .object({
+    limit: z.coerce.number().int().min(1).max(DIGEST_LIST_MAX_LIMIT).optional(),
+    cursor: z.string().min(1).max(64).optional(),
+  })
+  .strict();
+
+/** Error-envelope helpers — same shape documented in `docs/api.md#errors`. */
+function validationFailedBody(details: unknown): {
+  error: { code: string; message: string; details: unknown };
+} {
+  return {
+    error: {
+      code: 'validation_failed',
+      message: 'request failed validation',
+      details,
+    },
+  };
+}
+
+function notFoundBody(message: string): {
+  error: { code: string; message: string; details: Record<string, never> };
+} {
+  return {
+    error: { code: 'not_found', message, details: {} },
+  };
+}
+
+function unauthorizedBody(message: string): {
+  error: { code: string; message: string; details: Record<string, never> };
+} {
+  return {
+    error: { code: 'unauthorized', message, details: {} },
+  };
+}
+
+/**
+ * Minimal structural type for the request the controller touches.
+ * `SessionGuard` sets `req.user.id`; nothing else is read off `req`.
+ */
+interface RequestWithUser {
+  user?: { id: string };
+}
+
+@Controller('digests')
+@UseGuards(SessionGuard)
+export class DigestsController {
+  constructor(private readonly digests: DigestsService) {}
+
+  @Get()
+  async list(
+    @Req() req: RequestWithUser,
+    @Query() query: unknown,
+  ): Promise<DigestListResponse> {
+    const userId = requireUserId(req);
+    const parsed = ListDigestsQuerySchema.safeParse(query ?? {});
+    if (!parsed.success) {
+      throw new BadRequestException(validationFailedBody(parsed.error.issues));
+    }
+    const limit = parsed.data.limit ?? DIGEST_LIST_DEFAULT_LIMIT;
+    return this.digests.list(userId, limit, parsed.data.cursor);
+  }
+
+  @Get(':id')
+  async getById(
+    @Req() req: RequestWithUser,
+    @Param('id') id: string,
+  ): Promise<DigestDetail> {
+    const userId = requireUserId(req);
+    const digest = await this.digests.getById(userId, id);
+    if (!digest) {
+      throw new NotFoundException(notFoundBody('digest not found'));
+    }
+    return digest;
+  }
+
+  @Post('run-now')
+  @HttpCode(202)
+  async runNow(@Req() req: RequestWithUser): Promise<RunNowResult> {
+    const userId = requireUserId(req);
+    return this.digests.enqueueRunNow(userId);
+  }
+}
+
+/**
+ * Belt-and-braces check that mirrors `UsersController.requireUserId`.
+ * `SessionGuard` always sets `req.user.id` before the controller
+ * runs, but a future refactor that drops the guard from one of these
+ * routes must not silently pass an undefined id into the service. We
+ * surface this as `401 unauthorized` rather than `404` because the
+ * underlying problem is "no authenticated user", not "resource
+ * missing".
+ */
+function requireUserId(req: RequestWithUser): string {
+  const id = req.user?.id;
+  if (typeof id !== 'string' || id.length === 0) {
+    throw new UnauthorizedException(unauthorizedBody('no authenticated user'));
+  }
+  return id;
+}

--- a/src/digests/digests.module.ts
+++ b/src/digests/digests.module.ts
@@ -1,0 +1,62 @@
+import { type DynamicModule, Module } from '@nestjs/common';
+import { SESSION_COOKIE_MAX_AGE_SEC } from '../auth/auth.module';
+import {
+  SESSION_GUARD_CONFIG,
+  SessionGuard,
+  type SessionGuardConfig,
+} from '../common/session.guard';
+import type { Env } from '../config/env';
+import { DigestsRepo } from '../workers/digests.repo';
+import { DigestsController } from './digests.controller';
+import { DigestsService } from './digests.service';
+
+/**
+ * Wires the `/digests` HTTP surface.
+ *
+ * `forRoot(env)` so the session-guard config (HMAC secret) is bound
+ * once at boot — same pattern as `UsersModule.forRoot(env)`. Both
+ * modules MUST read from the same `SESSION_SECRET` so a cookie
+ * signed on the auth side verifies on either feature module.
+ *
+ * Providers:
+ *   - `DigestsService`        — list / getById / enqueueRunNow.
+ *   - `DigestsController`     — HTTP boundary.
+ *   - `DigestsRepo`           — re-provided locally; the repo lives
+ *                               under `src/workers/` so the processor
+ *                               can use it too, and `WorkersModule`
+ *                               exports it for cross-module reuse.
+ *                               Declaring it here as well keeps the
+ *                               DI graph for this module explicit
+ *                               even when a future test harness
+ *                               imports `DigestsModule` in isolation.
+ *   - `SessionGuard`          — gate on all three routes.
+ *   - `SESSION_GUARD_CONFIG`  — value provider holding the HMAC secret.
+ *
+ * The `BUILD_DIGEST_QUEUE` token that `DigestsService` injects lives
+ * in the `@Global()` `QueueModule`, so it doesn't need to be
+ * re-imported here.
+ */
+@Module({})
+export class DigestsModule {
+  static forRoot(env: Env): DynamicModule {
+    const sessionGuardConfig: SessionGuardConfig = {
+      sessionSecret: env.SESSION_SECRET,
+      sessionMaxAgeSec: SESSION_COOKIE_MAX_AGE_SEC,
+    };
+
+    return {
+      module: DigestsModule,
+      controllers: [DigestsController],
+      providers: [
+        DigestsService,
+        DigestsRepo,
+        SessionGuard,
+        {
+          provide: SESSION_GUARD_CONFIG,
+          useValue: sessionGuardConfig,
+        },
+      ],
+      exports: [DigestsService],
+    };
+  }
+}

--- a/src/digests/digests.service.test.ts
+++ b/src/digests/digests.service.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'bun:test';
+import type { DigestRecord, ListDigestsInput } from '../workers/digests.repo';
+import {
+  DIGEST_PREVIEW_LENGTH,
+  DigestsService,
+  type BuildDigestQueueProducer,
+} from './digests.service';
+
+class FakeDigestsRepo {
+  listCalls: ListDigestsInput[] = [];
+  listResult: { items: DigestRecord[]; nextCursor?: string } = { items: [] };
+  rows = new Map<string, DigestRecord>();
+
+  async listByUser(input: ListDigestsInput) {
+    this.listCalls.push(input);
+    return this.listResult;
+  }
+
+  async findByIdAndUser(
+    digestId: string,
+    userId: string,
+  ): Promise<DigestRecord | null> {
+    const row = this.rows.get(digestId);
+    if (!row || row.userId !== userId) return null;
+    return row;
+  }
+}
+
+class FakeQueue implements BuildDigestQueueProducer {
+  calls: Array<{ name: string; data: unknown; opts?: Record<string, unknown> }> = [];
+  nextId = 'job-1';
+
+  async add(name: string, data: unknown, opts?: Record<string, unknown>) {
+    this.calls.push({ name, data, opts });
+    return { id: this.nextId };
+  }
+}
+
+function makeService(): {
+  service: DigestsService;
+  repo: FakeDigestsRepo;
+  queue: FakeQueue;
+} {
+  const repo = new FakeDigestsRepo();
+  const queue = new FakeQueue();
+  const service = new DigestsService(repo as never, queue);
+  return { service, repo, queue };
+}
+
+function makeRow(overrides: Partial<DigestRecord> = {}): DigestRecord {
+  return {
+    id: 'd1',
+    userId: 'u1',
+    windowStart: '2026-04-05T00:00:00.000Z',
+    windowEnd: '2026-04-06T00:00:00.000Z',
+    markdown: '## digest',
+    itemIds: ['i1'],
+    model: 'anthropic/claude-sonnet-4.5',
+    tokensIn: 10,
+    tokensOut: 5,
+    createdAt: '2026-04-06T00:05:12.000Z',
+    ...overrides,
+  };
+}
+
+describe('DigestsService.list', () => {
+  it('delegates to repo.listByUser and attaches preview', async () => {
+    const { service, repo } = makeService();
+    repo.listResult = {
+      items: [makeRow({ id: 'd1', markdown: '## hi' })],
+    };
+    const result = await service.list('u1', 20, undefined);
+    expect(repo.listCalls[0]).toEqual({ userId: 'u1', limit: 20 });
+    expect(result.items[0]).toMatchObject({
+      id: 'd1',
+      preview: '## hi',
+      model: 'anthropic/claude-sonnet-4.5',
+    });
+    // No full markdown / tokens on list rows.
+    expect((result.items[0] as unknown as Record<string, unknown>).markdown).toBeUndefined();
+    expect(result.nextCursor).toBeUndefined();
+  });
+
+  it('truncates markdown to DIGEST_PREVIEW_LENGTH for the preview', async () => {
+    const { service, repo } = makeService();
+    const long = 'a'.repeat(DIGEST_PREVIEW_LENGTH * 2);
+    repo.listResult = { items: [makeRow({ markdown: long })] };
+    const result = await service.list('u1', 20, undefined);
+    expect(result.items[0]!.preview).toHaveLength(DIGEST_PREVIEW_LENGTH);
+  });
+
+  it('forwards cursor and nextCursor', async () => {
+    const { service, repo } = makeService();
+    repo.listResult = { items: [makeRow()], nextCursor: 'd_prev' };
+    const result = await service.list('u1', 5, 'd_start');
+    expect(repo.listCalls[0]).toEqual({ userId: 'u1', limit: 5, cursor: 'd_start' });
+    expect(result.nextCursor).toBe('d_prev');
+  });
+});
+
+describe('DigestsService.getById', () => {
+  it('returns the row when owned', async () => {
+    const { service, repo } = makeService();
+    const row = makeRow({ id: 'd1', userId: 'u1' });
+    repo.rows.set('d1', row);
+    const found = await service.getById('u1', 'd1');
+    expect(found).toEqual(row);
+  });
+
+  it('returns null when not owned', async () => {
+    const { service, repo } = makeService();
+    repo.rows.set('d1', makeRow({ id: 'd1', userId: 'u2' }));
+    const found = await service.getById('u1', 'd1');
+    expect(found).toBeNull();
+  });
+});
+
+describe('DigestsService.enqueueRunNow', () => {
+  it('enqueues with the documented retry policy and returns jobId + queuedAt', async () => {
+    const { service, queue } = makeService();
+    queue.nextId = 'job-42';
+    const result = await service.enqueueRunNow('u1');
+    expect(result.jobId).toBe('job-42');
+    expect(typeof result.queuedAt).toBe('string');
+    expect(queue.calls[0]!.name).toBe('build-digest');
+    expect(queue.calls[0]!.data).toEqual({ userId: 'u1' });
+    const opts = queue.calls[0]!.opts!;
+    expect(opts.attempts).toBe(3);
+    expect(opts.backoff).toEqual({ type: 'exponential', delay: 60_000 });
+  });
+});

--- a/src/digests/digests.service.ts
+++ b/src/digests/digests.service.ts
@@ -1,0 +1,165 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { BUILD_DIGEST_QUEUE } from '../queue/queue.tokens';
+import {
+  DigestsRepo,
+  type DigestRecord,
+  type ListDigestsResult,
+} from '../workers/digests.repo';
+
+/**
+ * Application service backing the `/digests` HTTP surface. Sits
+ * between `DigestsController` (HTTP boundary, zod validation) and
+ * `DigestsRepo` + the `build-digest` queue.
+ *
+ * Three responsibilities:
+ *
+ *   - `list(userId, limit, cursor)` — pagination for `GET /digests`.
+ *     Projects each row into the documented list shape (with the
+ *     `preview` trim applied) so the full markdown is never shipped
+ *     over the list endpoint.
+ *
+ *   - `getById(userId, digestId)` — full-row read for
+ *     `GET /digests/:id`. Scoped to the caller's userId so a malicious
+ *     client can't probe other users' digests by guessing document
+ *     ids. Returns `null` on both "not found" and "not yours"; the
+ *     controller collapses both to a `404`.
+ *
+ *   - `enqueueRunNow(userId)` — pushes a one-shot job onto the
+ *     `build-digest` queue for `POST /digests/run-now`. No window
+ *     override: the processor falls back to `[now - digestInterval,
+ *     now]`, matching the scheduler's cadence-driven runs.
+ */
+
+/**
+ * Structural type for the slice of BullMQ's `Queue.add` we actually
+ * call. Declared here (rather than importing the `bullmq` `Queue`
+ * class) so BullMQ types stay confined to `src/queue/` and
+ * `src/workers/` per the hexagonal rule in `docs/swe-config.json`.
+ */
+export interface BuildDigestQueueProducer {
+  add(
+    name: string,
+    data: unknown,
+    opts?: Record<string, unknown>,
+  ): Promise<{ id?: string | undefined }>;
+}
+
+/** Wire shape for a single row in `GET /digests`. */
+export interface DigestListItem {
+  id: string;
+  windowStart: string;
+  windowEnd: string;
+  model: string;
+  createdAt: string;
+  preview: string;
+}
+
+/** Wire shape for `GET /digests/:id`. Includes full markdown + usage. */
+export type DigestDetail = DigestRecord;
+
+/** Wire shape for `POST /digests/run-now`. */
+export interface RunNowResult {
+  jobId: string;
+  queuedAt: string;
+}
+
+/** Paginated response for `GET /digests`. */
+export interface DigestListResponse {
+  items: DigestListItem[];
+  nextCursor?: string;
+}
+
+/**
+ * Maximum length of the `preview` field returned on list rows. The API
+ * docs promise "~200 chars of markdown" — the constant lives here so
+ * the controller's wire contract is driven by a single source of
+ * truth, not a literal scattered through the service body.
+ */
+export const DIGEST_PREVIEW_LENGTH = 200;
+
+/** Hard cap on `limit` for the list endpoint. */
+export const DIGEST_LIST_MAX_LIMIT = 100;
+
+/** Default `limit` when the caller doesn't specify one. */
+export const DIGEST_LIST_DEFAULT_LIMIT = 20;
+
+@Injectable()
+export class DigestsService {
+  private readonly logger = new Logger(DigestsService.name);
+
+  constructor(
+    private readonly digests: DigestsRepo,
+    @Inject(BUILD_DIGEST_QUEUE)
+    private readonly buildDigestQueue: BuildDigestQueueProducer,
+  ) {}
+
+  async list(
+    userId: string,
+    limit: number,
+    cursor: string | undefined,
+  ): Promise<DigestListResponse> {
+    const raw: ListDigestsResult = await this.digests.listByUser({
+      userId,
+      limit,
+      ...(cursor !== undefined ? { cursor } : {}),
+    });
+    const items = raw.items.map(toListItem);
+    if (raw.nextCursor) {
+      return { items, nextCursor: raw.nextCursor };
+    }
+    return { items };
+  }
+
+  async getById(userId: string, digestId: string): Promise<DigestDetail | null> {
+    return this.digests.findByIdAndUser(digestId, userId);
+  }
+
+  /**
+   * Enqueue a one-shot `build-digest` job for the caller. Retry /
+   * removal policy matches the scheduler-driven run (see
+   * `docs/jobs.md`): 3 attempts, exponential backoff (60s base, 10m
+   * cap), `removeOnComplete` after a day, `removeOnFail` after a week.
+   *
+   * Returns the BullMQ-assigned `jobId` so the caller can correlate
+   * the eventual digest row with the 202 response. When BullMQ
+   * somehow doesn't return an id (shouldn't happen in practice, but
+   * the `Queue.add` type admits `undefined`), we fall back to an
+   * empty string rather than throw — a missing id only degrades
+   * observability, it doesn't invalidate the enqueue.
+   */
+  async enqueueRunNow(userId: string): Promise<RunNowResult> {
+    const job = await this.buildDigestQueue.add(
+      'build-digest',
+      { userId },
+      {
+        attempts: 3,
+        backoff: { type: 'exponential', delay: 60_000 },
+        removeOnComplete: { age: 86_400, count: 1000 },
+        removeOnFail: { age: 604_800 },
+      },
+    );
+    const queuedAt = new Date().toISOString();
+    this.logger.log('build-digest run-now enqueued', {
+      userId,
+      jobId: job.id,
+      queuedAt,
+    });
+    return { jobId: job.id ?? '', queuedAt };
+  }
+}
+
+function toListItem(record: DigestRecord): DigestListItem {
+  return {
+    id: record.id,
+    windowStart: record.windowStart,
+    windowEnd: record.windowEnd,
+    model: record.model,
+    createdAt: record.createdAt,
+    preview: truncatePreview(record.markdown),
+  };
+}
+
+function truncatePreview(markdown: string): string {
+  if (markdown.length <= DIGEST_PREVIEW_LENGTH) return markdown;
+  return markdown.slice(0, DIGEST_PREVIEW_LENGTH);
+}

--- a/src/workers/articles.repo.ts
+++ b/src/workers/articles.repo.ts
@@ -39,6 +39,9 @@ interface ArticlesDatabases {
 
 const COLLECTION_ID = 'articles';
 
+/** Max ids per `Query.equal('itemId', [...])` batch in `findByItemIds`. */
+const ITEM_ID_CHUNK_SIZE = 100;
+
 @Injectable()
 export class ArticlesRepo {
   private readonly databaseId: string;
@@ -95,6 +98,38 @@ export class ArticlesRepo {
       if (!winner) throw err;
       return winner;
     }
+  }
+
+  /**
+   * Load every article row whose `itemId` is in the given set. Returns
+   * an empty array when the input list is empty — callers don't have
+   * to guard against the "no items in window" branch themselves.
+   *
+   * Used by `BuildDigestProcessor` to hydrate the enriched items it
+   * pulled from `ItemsRepo.findEnrichedInWindow` with their extracted
+   * article bodies before handing them to `DigestGraph`. The
+   * `itemId_key` index declared in `scripts/setup-appwrite.ts` backs
+   * each equality query.
+   *
+   * The query is chunked because Appwrite's `Query.equal(attr, values)`
+   * accepts a bounded-size `values` array. 100 ids per request is
+   * comfortably under the SDK's limit and keeps a single digest
+   * window fitting inside a few round-trips even at the
+   * `MAX_WINDOW_ITEMS` ceiling in `ItemsRepo`.
+   */
+  async findByItemIds(itemIds: readonly string[]): Promise<ArticleRecord[]> {
+    if (itemIds.length === 0) return [];
+    const results: ArticleRecord[] = [];
+    for (let i = 0; i < itemIds.length; i += ITEM_ID_CHUNK_SIZE) {
+      const chunk = itemIds.slice(i, i + ITEM_ID_CHUNK_SIZE);
+      const page = await this.db.listDocuments({
+        databaseId: this.databaseId,
+        collectionId: COLLECTION_ID,
+        queries: [Query.equal('itemId', chunk as string[])],
+      });
+      for (const doc of page.documents) results.push(toArticleRecord(doc));
+    }
+    return results;
   }
 
   async findByItemIdAndUrl(itemId: string, url: string): Promise<ArticleRecord | null> {

--- a/src/workers/build-digest.processor.test.ts
+++ b/src/workers/build-digest.processor.test.ts
@@ -1,0 +1,306 @@
+import { describe, expect, it } from 'bun:test';
+import type { DigestGraph, DigestInput, DigestResult } from '../digest/graph/digest.graph';
+import type { UserRecord } from '../users/users.repo';
+import type { ArticleRecord } from './articles.repo';
+import { BuildDigestProcessor } from './build-digest.processor';
+import type { CreateDigestInput, DigestRecord } from './digests.repo';
+import type { ItemRecord } from './items.repo';
+
+/**
+ * Tests for the `build-digest` processor. The goal is to pin the
+ * acceptance criteria from issue #11:
+ *
+ *   - Valid payload → enriched items loaded → graph runs → a single
+ *     digests row is persisted with `markdown`, `itemIds`, `model`,
+ *     `tokensIn`, `tokensOut`.
+ *   - Empty window is a no-op (no row written, no throw).
+ *   - Invalid user / missing / non-active user is skipped (no throw,
+ *     no row).
+ *   - Malformed job payload is a non-retryable skip.
+ *
+ * Fakes follow the pattern established in `extract-item.processor.test.ts`.
+ */
+
+class FakeUsersRepo {
+  users = new Map<string, UserRecord>();
+  async findById(id: string): Promise<UserRecord | null> {
+    return this.users.get(id) ?? null;
+  }
+}
+
+class FakeItemsRepo {
+  items: ItemRecord[] = [];
+  windowCalls: Array<{ userId: string; start: Date; end: Date }> = [];
+
+  async findEnrichedInWindow(
+    userId: string,
+    start: Date,
+    end: Date,
+  ): Promise<ItemRecord[]> {
+    this.windowCalls.push({ userId, start, end });
+    return this.items.filter(
+      (i) =>
+        i.userId === userId &&
+        i.enriched &&
+        i.fetchedAt >= start.toISOString() &&
+        i.fetchedAt < end.toISOString(),
+    );
+  }
+}
+
+class FakeArticlesRepo {
+  articles: ArticleRecord[] = [];
+  async findByItemIds(itemIds: readonly string[]): Promise<ArticleRecord[]> {
+    const set = new Set(itemIds);
+    return this.articles.filter((a) => set.has(a.itemId));
+  }
+}
+
+class FakeDigestsRepo {
+  persisted: CreateDigestInput[] = [];
+  async create(input: CreateDigestInput): Promise<DigestRecord> {
+    this.persisted.push(input);
+    return {
+      id: `d-${this.persisted.length}`,
+      createdAt: new Date().toISOString(),
+      ...input,
+    };
+  }
+}
+
+class StubGraph {
+  calls: DigestInput[] = [];
+  result: DigestResult = {
+    markdown: '## digest\n',
+    itemIds: [],
+    usage: { tokensIn: 123, tokensOut: 45 },
+    model: 'anthropic/claude-sonnet-4.5',
+  };
+
+  async run(input: DigestInput): Promise<DigestResult> {
+    this.calls.push(input);
+    // Reflect the input item ids in the result so the processor can
+    // persist them — mirrors the real `DigestGraph.run` behavior.
+    return { ...this.result, itemIds: input.items.map((i) => i.id) };
+  }
+}
+
+class FakeLogger {
+  logs: Array<{ level: string; msg: string }> = [];
+  log(msg: string) {
+    this.logs.push({ level: 'log', msg });
+  }
+  warn(msg: string) {
+    this.logs.push({ level: 'warn', msg });
+  }
+}
+
+function makeItem(overrides: Partial<ItemRecord> = {}): ItemRecord {
+  return {
+    id: 'item-1',
+    userId: 'u1',
+    xTweetId: 't1',
+    kind: 'like',
+    text: 'check this',
+    authorHandle: 'alice',
+    urls: ['https://a.test'],
+    fetchedAt: new Date().toISOString(),
+    enriched: true,
+    ...overrides,
+  };
+}
+
+function makeUser(overrides: Partial<UserRecord> = {}): UserRecord {
+  return {
+    id: 'u1',
+    xUserId: '12345',
+    handle: 'alice',
+    status: 'active',
+    createdAt: '2026-04-01T00:00:00.000Z',
+    digestIntervalMin: 60,
+    ...overrides,
+  };
+}
+
+function makeProcessor() {
+  const users = new FakeUsersRepo();
+  const items = new FakeItemsRepo();
+  const articles = new FakeArticlesRepo();
+  const digests = new FakeDigestsRepo();
+  const graph = new StubGraph();
+  const logger = new FakeLogger();
+  const processor = new BuildDigestProcessor(
+    users as never,
+    items as never,
+    articles as never,
+    digests as never,
+    graph as unknown as DigestGraph,
+  );
+  Object.defineProperty(processor, 'logger', { value: logger });
+  return { processor, users, items, articles, digests, graph, logger };
+}
+
+describe('BuildDigestProcessor.process', () => {
+  it('loads enriched items + articles, runs the graph, and persists one digest row', async () => {
+    const { processor, users, items, articles, digests, graph } = makeProcessor();
+    users.users.set('u1', makeUser());
+    const now = Date.now();
+    items.items.push(
+      makeItem({ id: 'i1', fetchedAt: new Date(now - 30 * 60_000).toISOString() }),
+      makeItem({ id: 'i2', fetchedAt: new Date(now - 10 * 60_000).toISOString() }),
+    );
+    articles.articles.push({
+      id: 'a1',
+      itemId: 'i1',
+      url: 'https://a.test',
+      content: 'body',
+      extractedAt: new Date().toISOString(),
+      extractor: 'firecrawl',
+      title: 'A',
+    });
+
+    await processor.process({
+      data: { userId: 'u1' },
+      attemptsMade: 0,
+    });
+
+    expect(graph.calls).toHaveLength(1);
+    const call = graph.calls[0]!;
+    expect(call.items.map((i) => i.id)).toEqual(['i1', 'i2']);
+    expect(call.items[0]!.articles[0]).toEqual({
+      url: 'https://a.test',
+      content: 'body',
+      title: 'A',
+    });
+
+    expect(digests.persisted).toHaveLength(1);
+    const row = digests.persisted[0]!;
+    expect(row.userId).toBe('u1');
+    expect(row.markdown).toBe('## digest\n');
+    expect(row.itemIds).toEqual(['i1', 'i2']);
+    expect(row.model).toBe('anthropic/claude-sonnet-4.5');
+    expect(row.tokensIn).toBe(123);
+    expect(row.tokensOut).toBe(45);
+    expect(typeof row.windowStart).toBe('string');
+    expect(typeof row.windowEnd).toBe('string');
+  });
+
+  it('is a no-op when the window has zero enriched items', async () => {
+    const { processor, users, digests, graph } = makeProcessor();
+    users.users.set('u1', makeUser());
+
+    await processor.process({
+      data: { userId: 'u1' },
+      attemptsMade: 0,
+    });
+
+    expect(graph.calls).toHaveLength(0);
+    expect(digests.persisted).toHaveLength(0);
+  });
+
+  it('skips users not found', async () => {
+    const { processor, digests, graph } = makeProcessor();
+
+    await processor.process({
+      data: { userId: 'ghost' },
+      attemptsMade: 0,
+    });
+
+    expect(graph.calls).toHaveLength(0);
+    expect(digests.persisted).toHaveLength(0);
+  });
+
+  it('skips users not active (auth_expired / paused)', async () => {
+    const { processor, users, digests, graph } = makeProcessor();
+    users.users.set('u1', makeUser({ status: 'auth_expired' }));
+
+    await processor.process({
+      data: { userId: 'u1' },
+      attemptsMade: 0,
+    });
+
+    expect(graph.calls).toHaveLength(0);
+    expect(digests.persisted).toHaveLength(0);
+  });
+
+  it('uses job-supplied windowStart and windowEnd when provided', async () => {
+    const { processor, users, items, digests, graph } = makeProcessor();
+    users.users.set('u1', makeUser());
+    const windowStart = '2026-04-05T00:00:00.000Z';
+    const windowEnd = '2026-04-06T00:00:00.000Z';
+    items.items.push(
+      makeItem({ id: 'i1', fetchedAt: '2026-04-05T12:00:00.000Z' }),
+    );
+
+    await processor.process({
+      data: { userId: 'u1', windowStart, windowEnd },
+      attemptsMade: 0,
+    });
+
+    expect(graph.calls[0]!.window.start.toISOString()).toBe(windowStart);
+    expect(graph.calls[0]!.window.end.toISOString()).toBe(windowEnd);
+    expect(digests.persisted[0]!.windowStart).toBe(windowStart);
+    expect(digests.persisted[0]!.windowEnd).toBe(windowEnd);
+  });
+
+  it('falls back to the user cadence interval when windows are absent', async () => {
+    const { processor, users, items, graph } = makeProcessor();
+    users.users.set('u1', makeUser({ digestIntervalMin: 1440 }));
+    // Seed an item clearly inside a 24h window so the processor
+    // reaches the graph call — without a matching item the no-op
+    // branch returns before `graph.calls` is populated.
+    items.items.push(
+      makeItem({
+        id: 'i1',
+        fetchedAt: new Date(Date.now() - 60 * 60_000).toISOString(),
+      }),
+    );
+
+    await processor.process({
+      data: { userId: 'u1' },
+      attemptsMade: 0,
+    });
+
+    const { start, end } = graph.calls[0]!.window;
+    const spanMs = end.getTime() - start.getTime();
+    expect(spanMs).toBe(1440 * 60_000);
+  });
+
+  it('returns without throwing on malformed payloads (no retry)', async () => {
+    const { processor, digests, graph, logger } = makeProcessor();
+
+    await processor.process({ data: {}, attemptsMade: 0 });
+    await processor.process({ data: null, attemptsMade: 0 });
+    await processor.process({ data: { userId: '' }, attemptsMade: 0 });
+    await processor.process({
+      data: { userId: 'u1', windowStart: 'not-a-date' },
+      attemptsMade: 0,
+    });
+
+    expect(graph.calls).toHaveLength(0);
+    expect(digests.persisted).toHaveLength(0);
+    expect(
+      logger.logs.filter(
+        (l) => l.level === 'warn' && l.msg.includes('invalid job payload'),
+      ).length,
+    ).toBeGreaterThanOrEqual(3);
+  });
+
+  it('does not persist when the graph throws (so BullMQ retries)', async () => {
+    const { processor, users, items, digests, graph } = makeProcessor();
+    users.users.set('u1', makeUser());
+    items.items.push(
+      makeItem({
+        fetchedAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+      }),
+    );
+    graph.run = async () => {
+      throw new Error('graph boom');
+    };
+
+    await expect(
+      processor.process({ data: { userId: 'u1' }, attemptsMade: 0 }),
+    ).rejects.toThrow('graph boom');
+    expect(digests.persisted).toHaveLength(0);
+  });
+});

--- a/src/workers/build-digest.processor.ts
+++ b/src/workers/build-digest.processor.ts
@@ -47,11 +47,30 @@ export interface BuildDigestJob {
  * boundary. Window bounds are optional ISO-8601 strings; when absent
  * the processor falls back to `[now - digestIntervalMin, now]`.
  */
-const BuildDigestJobSchema = z.object({
-  userId: z.string().min(1),
-  windowStart: z.string().datetime().optional(),
-  windowEnd: z.string().datetime().optional(),
-});
+const BuildDigestJobSchema = z
+  .object({
+    userId: z.string().min(1),
+    windowStart: z.string().datetime().optional(),
+    windowEnd: z.string().datetime().optional(),
+  })
+  .superRefine((data, ctx) => {
+    // When both bounds are pinned (e.g. by `run-now` or a test), reject
+    // reversed windows at the boundary. Without this guard the downstream
+    // `findEnrichedInWindow` query silently returns zero items and the
+    // processor logs "no enriched items" — hiding a producer bug as a
+    // missing digest.
+    if (
+      data.windowStart !== undefined &&
+      data.windowEnd !== undefined &&
+      new Date(data.windowStart) >= new Date(data.windowEnd)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['windowStart'],
+        message: 'windowStart must be earlier than windowEnd',
+      });
+    }
+  });
 
 @Injectable()
 export class BuildDigestProcessor {

--- a/src/workers/build-digest.processor.ts
+++ b/src/workers/build-digest.processor.ts
@@ -1,0 +1,192 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { z } from 'zod';
+import { DigestGraph } from '../digest/graph/digest.graph';
+import type { EnrichedItem } from '../digest/graph/digest-state';
+import {
+  DEFAULT_DIGEST_INTERVAL_MIN,
+} from '../users/cadence.constants';
+import { UsersRepo } from '../users/users.repo';
+import { ArticlesRepo, type ArticleRecord } from './articles.repo';
+import { DigestsRepo } from './digests.repo';
+import { ItemsRepo, type ItemRecord } from './items.repo';
+
+/**
+ * BullMQ job handler for the `build-digest` queue.
+ *
+ * Lifecycle (see `docs/jobs.md#builddigestprocessor`):
+ *
+ *   1. Validate the payload at the worker boundary with zod. Malformed
+ *      jobs are non-recoverable (retry won't fix a missing field), so
+ *      log and return — no throw.
+ *   2. Load the user. If missing or not `active`, skip: a digest for a
+ *      deleted / paused / auth-expired user is meaningless.
+ *   3. Resolve the window: `windowEnd = data.windowEnd ?? now`,
+ *      `windowStart = data.windowStart ?? windowEnd - digestIntervalMin`.
+ *   4. Load enriched items in `[windowStart, windowEnd)` and the
+ *      article rows that belong to them.
+ *   5. If there are zero enriched items, log and return — no empty
+ *      digest row. This is the "no-op on empty window" acceptance
+ *      criterion in issue #11.
+ *   6. Assemble `EnrichedItem[]` and call `DigestGraph.run`.
+ *   7. Persist one `digests` row with markdown + usage + model.
+ *
+ * The processor never imports BullMQ types directly; it receives a
+ * structural `BuildDigestJob` and the `WorkersLifecycle` in
+ * `workers.module.ts` is the only caller, matching the pattern
+ * `PollXProcessor` and `ExtractItemProcessor` already use.
+ */
+
+/** Minimal job shape — no BullMQ types in the public interface. */
+export interface BuildDigestJob {
+  data: unknown;
+  attemptsMade: number;
+}
+
+/**
+ * Zod schema validating the `build-digest` job payload at the worker
+ * boundary. Window bounds are optional ISO-8601 strings; when absent
+ * the processor falls back to `[now - digestIntervalMin, now]`.
+ */
+const BuildDigestJobSchema = z.object({
+  userId: z.string().min(1),
+  windowStart: z.string().datetime().optional(),
+  windowEnd: z.string().datetime().optional(),
+});
+
+@Injectable()
+export class BuildDigestProcessor {
+  private readonly logger = new Logger(BuildDigestProcessor.name);
+
+  constructor(
+    private readonly users: UsersRepo,
+    private readonly items: ItemsRepo,
+    private readonly articles: ArticlesRepo,
+    private readonly digests: DigestsRepo,
+    private readonly graph: DigestGraph,
+  ) {}
+
+  async process(job: BuildDigestJob): Promise<void> {
+    const parsed = BuildDigestJobSchema.safeParse(job.data);
+    if (!parsed.success) {
+      const issues = parsed.error.issues
+        .map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`)
+        .join('; ');
+      this.logger.warn(`skipping build-digest: invalid job payload — ${issues}`);
+      return;
+    }
+    const { userId } = parsed.data;
+    const start = Date.now();
+
+    const user = await this.users.findById(userId);
+    if (!user) {
+      this.logger.warn(`skipping build-digest: user ${userId} not found`);
+      return;
+    }
+    if (user.status !== 'active') {
+      this.logger.warn(
+        `skipping build-digest: user ${userId} is ${user.status}`,
+      );
+      return;
+    }
+
+    // Resolve the window. The caller can pin either bound (for the
+    // `POST /digests/run-now` manual trigger and for tests); the
+    // scheduler leaves both absent so we walk the user's cadence
+    // backwards from `now`.
+    const windowEnd = parsed.data.windowEnd
+      ? new Date(parsed.data.windowEnd)
+      : new Date();
+    const intervalMs =
+      (user.digestIntervalMin ?? DEFAULT_DIGEST_INTERVAL_MIN) * 60_000;
+    const windowStart = parsed.data.windowStart
+      ? new Date(parsed.data.windowStart)
+      : new Date(windowEnd.getTime() - intervalMs);
+
+    const enrichedItems = await this.items.findEnrichedInWindow(
+      userId,
+      windowStart,
+      windowEnd,
+    );
+    if (enrichedItems.length === 0) {
+      this.logger.log(
+        `no enriched items for user ${userId} in window ${windowStart.toISOString()}..${windowEnd.toISOString()}, skipping`,
+      );
+      return;
+    }
+
+    const articleRecords = await this.articles.findByItemIds(
+      enrichedItems.map((i) => i.id),
+    );
+    const articlesByItemId = groupArticlesByItemId(articleRecords);
+
+    const graphItems: EnrichedItem[] = enrichedItems.map((item) =>
+      toEnrichedItem(item, articlesByItemId.get(item.id) ?? []),
+    );
+
+    const result = await this.graph.run({
+      userId,
+      window: { start: windowStart, end: windowEnd },
+      items: graphItems,
+    });
+
+    await this.digests.create({
+      userId,
+      windowStart: windowStart.toISOString(),
+      windowEnd: windowEnd.toISOString(),
+      markdown: result.markdown,
+      itemIds: result.itemIds,
+      model: result.model,
+      tokensIn: result.usage.tokensIn,
+      tokensOut: result.usage.tokensOut,
+    });
+
+    const durationMs = Date.now() - start;
+    this.logger.log('build-digest complete', {
+      userId,
+      attempt: job.attemptsMade + 1,
+      durationMs,
+      itemsIncluded: graphItems.length,
+      tokensIn: result.usage.tokensIn,
+      tokensOut: result.usage.tokensOut,
+      model: result.model,
+    });
+  }
+}
+
+function groupArticlesByItemId(
+  articles: ArticleRecord[],
+): Map<string, ArticleRecord[]> {
+  const grouped = new Map<string, ArticleRecord[]>();
+  for (const article of articles) {
+    const bucket = grouped.get(article.itemId);
+    if (bucket) {
+      bucket.push(article);
+    } else {
+      grouped.set(article.itemId, [article]);
+    }
+  }
+  return grouped;
+}
+
+function toEnrichedItem(
+  item: ItemRecord,
+  articles: ArticleRecord[],
+): EnrichedItem {
+  return {
+    id: item.id,
+    text: item.text,
+    authorHandle: item.authorHandle,
+    kind: item.kind,
+    articles: articles.map((a) => {
+      // Only emit optional fields when they're present so downstream
+      // prompt templates don't render empty `undefined` noise.
+      const out: EnrichedItem['articles'][number] = {
+        url: a.url,
+        content: a.content,
+      };
+      if (a.title !== undefined) out.title = a.title;
+      if (a.siteName !== undefined) out.siteName = a.siteName;
+      return out;
+    }),
+  };
+}

--- a/src/workers/digests.repo.test.ts
+++ b/src/workers/digests.repo.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'bun:test';
+import { DigestsRepo } from './digests.repo';
+
+/**
+ * In-memory fake of the Appwrite databases slice that `DigestsRepo`
+ * uses. Supports the queries the repo actually issues:
+ *   - `createDocument`
+ *   - `getDocument`
+ *   - `listDocuments` with `equal`, `orderDesc`, `limit`, `cursorAfter`.
+ */
+class FakeDatabases {
+  readonly docs = new Map<string, Record<string, unknown> & { $id: string }>();
+  private nextId = 1;
+
+  async createDocument(params: {
+    databaseId: string;
+    collectionId: string;
+    documentId: string;
+    data: Record<string, unknown>;
+  }): Promise<Record<string, unknown> & { $id: string }> {
+    const id = `doc-${this.nextId++}`;
+    const doc = { $id: id, ...params.data };
+    this.docs.set(id, doc);
+    return doc;
+  }
+
+  async getDocument(params: {
+    databaseId: string;
+    collectionId: string;
+    documentId: string;
+  }): Promise<Record<string, unknown> & { $id: string }> {
+    const doc = this.docs.get(params.documentId);
+    if (!doc) {
+      const err = new Error('not found') as Error & { code: number };
+      err.code = 404;
+      throw err;
+    }
+    return doc;
+  }
+
+  async listDocuments(params: {
+    databaseId: string;
+    collectionId: string;
+    queries?: string[];
+  }): Promise<{ total: number; documents: Array<Record<string, unknown> & { $id: string }> }> {
+    let orderAttr: string | undefined;
+    let orderDesc = false;
+    let limit = Number.POSITIVE_INFINITY;
+    let cursorAfter: string | undefined;
+    const filters: Array<[string, string]> = [];
+    for (const q of params.queries ?? []) {
+      const parsed = JSON.parse(q) as {
+        method?: string;
+        attribute?: string;
+        values?: unknown[];
+      };
+      switch (parsed.method) {
+        case 'equal':
+          filters.push([
+            String(parsed.attribute),
+            String((parsed.values ?? [])[0]),
+          ]);
+          break;
+        case 'orderDesc':
+          orderAttr = String(parsed.attribute);
+          orderDesc = true;
+          break;
+        case 'orderAsc':
+          orderAttr = String(parsed.attribute);
+          orderDesc = false;
+          break;
+        case 'limit':
+          limit = Number((parsed.values ?? [])[0]);
+          break;
+        case 'cursorAfter':
+          cursorAfter = String((parsed.values ?? [])[0]);
+          break;
+      }
+    }
+
+    let matched = Array.from(this.docs.values()).filter((d) =>
+      filters.every(([field, value]) => String(d[field]) === value),
+    );
+    if (orderAttr) {
+      matched.sort((a, b) => {
+        const av = String(a[orderAttr!] ?? '');
+        const bv = String(b[orderAttr!] ?? '');
+        return orderDesc ? (av < bv ? 1 : av > bv ? -1 : 0) : av < bv ? -1 : av > bv ? 1 : 0;
+      });
+    }
+    if (cursorAfter) {
+      const idx = matched.findIndex((d) => d.$id === cursorAfter);
+      if (idx >= 0) matched = matched.slice(idx + 1);
+    }
+    if (Number.isFinite(limit)) matched = matched.slice(0, limit);
+    return { total: matched.length, documents: matched };
+  }
+}
+
+function makeRepo(): { repo: DigestsRepo; db: FakeDatabases } {
+  const db = new FakeDatabases();
+  const fakeAppwrite = {
+    databaseId: 'test-db',
+    databases: db as unknown as never,
+  };
+  return { repo: new DigestsRepo(fakeAppwrite as never), db };
+}
+
+const BASE_INPUT = {
+  userId: 'u1',
+  windowStart: '2026-04-05T00:00:00.000Z',
+  windowEnd: '2026-04-06T00:00:00.000Z',
+  markdown: '## hi',
+  itemIds: ['i1', 'i2'],
+  model: 'anthropic/claude-sonnet-4.5',
+  tokensIn: 10,
+  tokensOut: 5,
+};
+
+describe('DigestsRepo.create', () => {
+  it('persists every documented field and returns a parsed record', async () => {
+    const { repo, db } = makeRepo();
+    const result = await repo.create(BASE_INPUT);
+    expect(typeof result.id).toBe('string');
+    expect(result.userId).toBe('u1');
+    expect(result.itemIds).toEqual(['i1', 'i2']);
+    expect(result.model).toBe('anthropic/claude-sonnet-4.5');
+    expect(result.tokensIn).toBe(10);
+    expect(result.tokensOut).toBe(5);
+    const stored = db.docs.get(result.id);
+    expect(typeof stored?.createdAt).toBe('string');
+  });
+});
+
+describe('DigestsRepo.findByIdAndUser', () => {
+  it('returns the row when owned by the caller', async () => {
+    const { repo } = makeRepo();
+    const created = await repo.create(BASE_INPUT);
+    const found = await repo.findByIdAndUser(created.id, 'u1');
+    expect(found?.id).toBe(created.id);
+    expect(found?.markdown).toBe('## hi');
+  });
+
+  it('returns null when the row belongs to a different user', async () => {
+    const { repo } = makeRepo();
+    const created = await repo.create(BASE_INPUT);
+    const found = await repo.findByIdAndUser(created.id, 'someone-else');
+    expect(found).toBeNull();
+  });
+
+  it('returns null when the id does not exist', async () => {
+    const { repo } = makeRepo();
+    const found = await repo.findByIdAndUser('nope', 'u1');
+    expect(found).toBeNull();
+  });
+});
+
+describe('DigestsRepo.listByUser', () => {
+  it('returns rows newest first for the given user', async () => {
+    const { repo } = makeRepo();
+    // Seed three rows with distinct createdAt via sequential awaits.
+    // FakeDatabases' createDocument stamps incrementing ids, and the
+    // repo writes `new Date().toISOString()` at insert time, so the
+    // rows end up ordered by insertion time.
+    const a = await repo.create(BASE_INPUT);
+    await new Promise((r) => setTimeout(r, 2));
+    const b = await repo.create(BASE_INPUT);
+    await new Promise((r) => setTimeout(r, 2));
+    const c = await repo.create(BASE_INPUT);
+
+    const result = await repo.listByUser({ userId: 'u1', limit: 10 });
+    expect(result.items.map((i) => i.id)).toEqual([c.id, b.id, a.id]);
+    expect(result.nextCursor).toBeUndefined();
+  });
+
+  it('scopes listings by userId', async () => {
+    const { repo } = makeRepo();
+    await repo.create({ ...BASE_INPUT, userId: 'u1' });
+    await repo.create({ ...BASE_INPUT, userId: 'u2' });
+    const result = await repo.listByUser({ userId: 'u1', limit: 10 });
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]!.userId).toBe('u1');
+  });
+
+  it('paginates via nextCursor', async () => {
+    const { repo } = makeRepo();
+    const ids: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      await new Promise((r) => setTimeout(r, 2));
+      const row = await repo.create(BASE_INPUT);
+      ids.push(row.id);
+    }
+    const expectedNewestFirst = [...ids].reverse();
+    const page1 = await repo.listByUser({ userId: 'u1', limit: 2 });
+    expect(page1.items.map((i) => i.id)).toEqual(expectedNewestFirst.slice(0, 2));
+    expect(page1.nextCursor).toBe(expectedNewestFirst[1]);
+
+    const page2 = await repo.listByUser({
+      userId: 'u1',
+      limit: 2,
+      cursor: page1.nextCursor,
+    });
+    expect(page2.items.map((i) => i.id)).toEqual(expectedNewestFirst.slice(2, 4));
+    expect(page2.nextCursor).toBe(expectedNewestFirst[3]);
+
+    const page3 = await repo.listByUser({
+      userId: 'u1',
+      limit: 2,
+      cursor: page2.nextCursor,
+    });
+    expect(page3.items.map((i) => i.id)).toEqual(expectedNewestFirst.slice(4, 5));
+    expect(page3.nextCursor).toBeUndefined();
+  });
+});

--- a/src/workers/digests.repo.test.ts
+++ b/src/workers/digests.repo.test.ts
@@ -123,6 +123,9 @@ describe('DigestsRepo.create', () => {
     const result = await repo.create(BASE_INPUT);
     expect(typeof result.id).toBe('string');
     expect(result.userId).toBe('u1');
+    expect(result.windowStart).toBe('2026-04-05T00:00:00.000Z');
+    expect(result.windowEnd).toBe('2026-04-06T00:00:00.000Z');
+    expect(result.markdown).toBe('## hi');
     expect(result.itemIds).toEqual(['i1', 'i2']);
     expect(result.model).toBe('anthropic/claude-sonnet-4.5');
     expect(result.tokensIn).toBe(10);

--- a/src/workers/digests.repo.ts
+++ b/src/workers/digests.repo.ts
@@ -1,0 +1,209 @@
+import { Injectable } from '@nestjs/common';
+import { ID, Query } from 'node-appwrite';
+import { AppwriteService } from '../appwrite/appwrite.service';
+
+/**
+ * Thin adapter over `AppwriteService.databases` for the `digests`
+ * collection. Mirrors the `ItemsRepo` / `ArticlesRepo` patterns: the
+ * only SDK slice we depend on is declared as a structural type so tests
+ * can swap in an in-memory fake.
+ *
+ * Write path: `BuildDigestProcessor.create` persists one row per
+ * successful graph run.
+ *
+ * Read path: `DigestsService` backs `GET /digests` (paginated list,
+ * newest first, trimmed to a `preview`) and `GET /digests/:id` (full
+ * row). Both reads constrain by `userId` so a malicious caller cannot
+ * read another user's digests by guessing an id.
+ */
+
+export interface DigestRecord {
+  id: string;
+  userId: string;
+  windowStart: string;
+  windowEnd: string;
+  markdown: string;
+  itemIds: string[];
+  model: string;
+  tokensIn: number;
+  tokensOut: number;
+  createdAt: string;
+}
+
+export interface CreateDigestInput {
+  userId: string;
+  windowStart: string;
+  windowEnd: string;
+  markdown: string;
+  itemIds: string[];
+  model: string;
+  tokensIn: number;
+  tokensOut: number;
+}
+
+export interface ListDigestsInput {
+  userId: string;
+  limit: number;
+  /** Document id to resume after (exclusive). */
+  cursor?: string;
+}
+
+export interface ListDigestsResult {
+  items: DigestRecord[];
+  nextCursor?: string;
+}
+
+interface DigestsDatabases {
+  createDocument(params: {
+    databaseId: string;
+    collectionId: string;
+    documentId: string;
+    data: Record<string, unknown>;
+  }): Promise<Record<string, unknown> & { $id: string }>;
+  getDocument(params: {
+    databaseId: string;
+    collectionId: string;
+    documentId: string;
+  }): Promise<Record<string, unknown> & { $id: string }>;
+  listDocuments(params: {
+    databaseId: string;
+    collectionId: string;
+    queries?: string[];
+  }): Promise<{ total: number; documents: Array<Record<string, unknown> & { $id: string }> }>;
+}
+
+const COLLECTION_ID = 'digests';
+
+@Injectable()
+export class DigestsRepo {
+  private readonly databaseId: string;
+  private readonly db: DigestsDatabases;
+
+  constructor(appwrite: AppwriteService) {
+    this.databaseId = appwrite.databaseId;
+    this.db = appwrite.databases as unknown as DigestsDatabases;
+  }
+
+  /** Persist one digest row and return the parsed record. */
+  async create(input: CreateDigestInput): Promise<DigestRecord> {
+    const createdAt = new Date().toISOString();
+    const created = await this.db.createDocument({
+      databaseId: this.databaseId,
+      collectionId: COLLECTION_ID,
+      documentId: ID.unique(),
+      data: {
+        userId: input.userId,
+        windowStart: input.windowStart,
+        windowEnd: input.windowEnd,
+        markdown: input.markdown,
+        itemIds: input.itemIds,
+        model: input.model,
+        tokensIn: input.tokensIn,
+        tokensOut: input.tokensOut,
+        createdAt,
+      },
+    });
+    return toDigestRecord(created);
+  }
+
+  /**
+   * Look up a digest by id, scoped to the owning user. Returns `null`
+   * both when the row doesn't exist and when it belongs to someone
+   * else — the controller collapses both to a 404 so callers cannot
+   * probe for other users' digest ids.
+   */
+  async findByIdAndUser(
+    digestId: string,
+    userId: string,
+  ): Promise<DigestRecord | null> {
+    try {
+      const doc = await this.db.getDocument({
+        databaseId: this.databaseId,
+        collectionId: COLLECTION_ID,
+        documentId: digestId,
+      });
+      const record = toDigestRecord(doc);
+      if (record.userId !== userId) return null;
+      return record;
+    } catch (err) {
+      if (isNotFound(err)) return null;
+      throw err;
+    }
+  }
+
+  /**
+   * Paginated list for `GET /digests`, newest first. Pagination is
+   * cursor-based on the document id rather than offset-based so
+   * in-flight inserts don't shift the window under the caller. We
+   * fetch `limit + 1` rows so a non-empty `nextCursor` is returned iff
+   * there is at least one more row beyond the page.
+   *
+   * The `userId, createdAt` descending index (see
+   * `scripts/setup-appwrite.ts`) backs the sort.
+   */
+  async listByUser(input: ListDigestsInput): Promise<ListDigestsResult> {
+    const queries: string[] = [
+      Query.equal('userId', input.userId),
+      Query.orderDesc('createdAt'),
+      Query.limit(input.limit + 1),
+    ];
+    if (input.cursor) queries.push(Query.cursorAfter(input.cursor));
+    const result = await this.db.listDocuments({
+      databaseId: this.databaseId,
+      collectionId: COLLECTION_ID,
+      queries,
+    });
+    const all = result.documents.map(toDigestRecord);
+    if (all.length <= input.limit) {
+      return { items: all };
+    }
+    const page = all.slice(0, input.limit);
+    const last = page[page.length - 1]!;
+    return { items: page, nextCursor: last.id };
+  }
+}
+
+function isNotFound(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  return (err as { code?: number }).code === 404;
+}
+
+function toDigestRecord(doc: Record<string, unknown> & { $id: string }): DigestRecord {
+  const userId = doc.userId;
+  const windowStart = doc.windowStart;
+  const windowEnd = doc.windowEnd;
+  const markdown = doc.markdown;
+  const itemIds = doc.itemIds;
+  const model = doc.model;
+  const tokensIn = doc.tokensIn;
+  const tokensOut = doc.tokensOut;
+  const createdAt = doc.createdAt;
+  if (
+    typeof userId !== 'string' ||
+    typeof windowStart !== 'string' ||
+    typeof windowEnd !== 'string' ||
+    typeof markdown !== 'string' ||
+    typeof model !== 'string' ||
+    typeof createdAt !== 'string'
+  ) {
+    throw new Error(`digests row ${doc.$id} is missing required string fields`);
+  }
+  if (!Array.isArray(itemIds)) {
+    throw new Error(`digests row ${doc.$id} has non-array itemIds`);
+  }
+  if (typeof tokensIn !== 'number' || typeof tokensOut !== 'number') {
+    throw new Error(`digests row ${doc.$id} has non-numeric token fields`);
+  }
+  return {
+    id: doc.$id,
+    userId,
+    windowStart,
+    windowEnd,
+    markdown,
+    itemIds: itemIds.map(String),
+    model,
+    tokensIn,
+    tokensOut,
+    createdAt,
+  };
+}

--- a/src/workers/items.repo.ts
+++ b/src/workers/items.repo.ts
@@ -42,6 +42,19 @@ interface ItemsDatabases {
 
 const COLLECTION_ID = 'items';
 
+/**
+ * Hard cap on the number of items a single digest window pulls back.
+ * The `build-digest` processor feeds the result into `DigestGraph`,
+ * which tokenises every article body; an unbounded scan would let one
+ * pathological user (or a misconfigured cadence) produce prompts
+ * large enough to blow the LLM context window. 500 is well above the
+ * largest digest we expect in practice (the default daily cadence
+ * caps at whatever a user can plausibly like in 24h) while still
+ * fitting comfortably under every adapter's list-documents paging
+ * limit.
+ */
+const MAX_WINDOW_ITEMS = 500;
+
 @Injectable()
 export class ItemsRepo {
   private readonly databaseId: string;
@@ -121,6 +134,37 @@ export class ItemsRepo {
       documentId: itemId,
       data: { enriched: true },
     });
+  }
+
+  /**
+   * List enriched items for a user whose `fetchedAt` falls in the
+   * half-open window `[start, end)`. Ordered oldest-first so the
+   * downstream digest graph sees items in the sequence they were
+   * ingested.
+   *
+   * Used by `BuildDigestProcessor` to gather the source set for a
+   * digest window. The `(userId, fetchedAt desc)` and
+   * `(userId, enriched)` indexes declared in
+   * `scripts/setup-appwrite.ts` back the scan.
+   */
+  async findEnrichedInWindow(
+    userId: string,
+    start: Date,
+    end: Date,
+  ): Promise<ItemRecord[]> {
+    const result = await this.db.listDocuments({
+      databaseId: this.databaseId,
+      collectionId: COLLECTION_ID,
+      queries: [
+        Query.equal('userId', userId),
+        Query.equal('enriched', true),
+        Query.greaterThanEqual('fetchedAt', start.toISOString()),
+        Query.lessThan('fetchedAt', end.toISOString()),
+        Query.orderAsc('fetchedAt'),
+        Query.limit(MAX_WINDOW_ITEMS),
+      ],
+    });
+    return result.documents.map(toItemRecord);
   }
 
   /** Query by compound key. Returns `null` on miss. */

--- a/src/workers/workers.module.ts
+++ b/src/workers/workers.module.ts
@@ -9,11 +9,14 @@ import { Worker } from 'bullmq';
 import type { Redis } from 'ioredis';
 import type { Env } from '../config/env';
 import {
+  BUILD_DIGEST_QUEUE_NAME,
   EXTRACT_ITEM_QUEUE_NAME,
   POLL_X_QUEUE_NAME,
   REDIS_CLIENT,
 } from '../queue/queue.tokens';
 import { ArticlesRepo } from './articles.repo';
+import { BuildDigestProcessor } from './build-digest.processor';
+import { DigestsRepo } from './digests.repo';
 import { ExtractItemProcessor } from './extract-item.processor';
 import { ItemsRepo } from './items.repo';
 import { PollXProcessor } from './poll-x.processor';
@@ -21,8 +24,8 @@ import { PollXProcessor } from './poll-x.processor';
 /**
  * Owns BullMQ `Worker` instances for all processor queues.
  *
- * Registers the `poll-x` worker (#7) and the `extract-item` worker (#8).
- * A future milestone (#11 `build-digest`) adds another worker here.
+ * Registers the `poll-x` worker (#7), the `extract-item` worker (#8),
+ * and the `build-digest` worker (#11).
  *
  * Worker creation and shutdown live in `WorkersLifecycle`, a separate
  * injectable registered as a provider. This follows the same pattern
@@ -33,10 +36,12 @@ import { PollXProcessor } from './poll-x.processor';
 
 const POLL_X_CONCURRENCY = 'POLL_X_CONCURRENCY';
 const EXTRACT_ITEM_CONCURRENCY = 'EXTRACT_ITEM_CONCURRENCY';
+const BUILD_DIGEST_CONCURRENCY = 'BUILD_DIGEST_CONCURRENCY';
 
 export interface WorkerConcurrency {
   pollX: number;
   extractItem: number;
+  buildDigest: number;
 }
 
 /**
@@ -47,12 +52,14 @@ export class WorkersLifecycle implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(WorkersLifecycle.name);
   private pollXWorker?: Worker;
   private extractItemWorker?: Worker;
+  private buildDigestWorker?: Worker;
 
   constructor(
     private readonly redis: Redis,
     private readonly concurrency: WorkerConcurrency,
     private readonly pollXProcessor: PollXProcessor,
     private readonly extractItemProcessor: ExtractItemProcessor,
+    private readonly buildDigestProcessor: BuildDigestProcessor,
   ) {}
 
   onModuleInit() {
@@ -77,11 +84,24 @@ export class WorkersLifecycle implements OnModuleInit, OnModuleDestroy {
     this.logger.log(
       `extract-item worker started (concurrency: ${this.concurrency.extractItem})`,
     );
+
+    this.buildDigestWorker = new Worker(
+      BUILD_DIGEST_QUEUE_NAME,
+      async (job) => this.buildDigestProcessor.process(job),
+      {
+        connection: this.redis,
+        concurrency: this.concurrency.buildDigest,
+      },
+    );
+    this.logger.log(
+      `build-digest worker started (concurrency: ${this.concurrency.buildDigest})`,
+    );
   }
 
   async onModuleDestroy(): Promise<void> {
     await this.closeWorker(this.pollXWorker, 'poll-x');
     await this.closeWorker(this.extractItemWorker, 'extract-item');
+    await this.closeWorker(this.buildDigestWorker, 'build-digest');
   }
 
   private async closeWorker(worker: Worker | undefined, name: string): Promise<void> {
@@ -104,34 +124,47 @@ export class WorkersModule {
       providers: [
         ItemsRepo,
         ArticlesRepo,
+        DigestsRepo,
         PollXProcessor,
         ExtractItemProcessor,
+        BuildDigestProcessor,
         { provide: POLL_X_CONCURRENCY, useValue: env.POLL_X_CONCURRENCY },
         { provide: EXTRACT_ITEM_CONCURRENCY, useValue: env.EXTRACT_ITEM_CONCURRENCY },
+        { provide: BUILD_DIGEST_CONCURRENCY, useValue: env.BUILD_DIGEST_CONCURRENCY },
         {
           provide: WorkersLifecycle,
           useFactory: (
             redis: Redis,
             pollXConcurrency: number,
             extractItemConcurrency: number,
+            buildDigestConcurrency: number,
             pollX: PollXProcessor,
             extractItem: ExtractItemProcessor,
+            buildDigest: BuildDigestProcessor,
           ) =>
             new WorkersLifecycle(
               redis,
-              { pollX: pollXConcurrency, extractItem: extractItemConcurrency },
+              {
+                pollX: pollXConcurrency,
+                extractItem: extractItemConcurrency,
+                buildDigest: buildDigestConcurrency,
+              },
               pollX,
               extractItem,
+              buildDigest,
             ),
           inject: [
             REDIS_CLIENT,
             POLL_X_CONCURRENCY,
             EXTRACT_ITEM_CONCURRENCY,
+            BUILD_DIGEST_CONCURRENCY,
             PollXProcessor,
             ExtractItemProcessor,
+            BuildDigestProcessor,
           ],
         },
       ],
+      exports: [DigestsRepo],
     };
   }
 }


### PR DESCRIPTION
## Summary
- `BuildDigestProcessor` resolves the window (job-supplied or `[now - digestIntervalMin, now]`), loads enriched items + articles, runs `DigestGraph`, and persists one `digests` row with `markdown`, `itemIds`, `model`, `tokensIn`, `tokensOut`. Empty windows are a no-op; missing or non-active users are skipped without throwing.
- `DigestsRepo` (new, under `src/workers/`) provides `create`, owner-scoped `findByIdAndUser`, and cursor-paginated `listByUser` backed by the `userId, createdAt desc` index.
- `ItemsRepo.findEnrichedInWindow` and `ArticlesRepo.findByItemIds` added as the query helpers the processor needs, capped at 500 items per window and chunked at 100 ids per batch respectively.
- `/digests` HTTP surface: `GET /digests?limit&cursor` (newest first, rows trimmed to a `preview`), `GET /digests/:id` (404 when not owned, collapsed with "missing" so ids can't be probed), `POST /digests/run-now` returning `202 { jobId, queuedAt }` after enqueuing a one-shot `build-digest` job with the documented retry policy (3 attempts, exponential 60s base, 10m cap).
- `WorkersLifecycle` now owns the third BullMQ Worker alongside `poll-x` and `extract-item`. `BUILD_DIGEST_CONCURRENCY` env knob (default 2) is wired through.
- Version bumped to `0.10.0`.

## Test plan
- [x] `bun test` — 382 pass, 1 pre-existing `IngestionModule.forRoot` failure (Redis-dependent, documented in the issue).
- [x] `bunx tsc --noEmit` clean.
- [x] `bunx biome lint .` — warnings only, no errors; new files match the non-null-assertion patterns already established in the workers layer.
- [x] New unit tests: `digests.repo.test.ts`, `build-digest.processor.test.ts`, `digests.service.test.ts`, `digests.controller.test.ts`.

Closes #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added digest management capabilities: users can now list and view their digests, with support for pagination and filtering. Added ability to manually trigger digest generation on-demand.

* **Chores**
  * Bumped version to 0.10.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->