### PR TITLE
chore: docker-compose + README run steps (#13)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,15 +3,18 @@ PORT=3000
 NODE_ENV=development
 
 # ----- Appwrite -----
+# Use Appwrite Cloud (https://cloud.appwrite.io/v1) or a self-hosted endpoint.
 APPWRITE_ENDPOINT=https://cloud.appwrite.io/v1
 APPWRITE_PROJECT_ID=
 APPWRITE_API_KEY=
 APPWRITE_DATABASE_ID=xreporter
 
 # ----- Redis (BullMQ) -----
+# Must use redis:// or rediss:// scheme. `docker compose up -d` exposes 6379.
 REDIS_URL=redis://localhost:6379
 
 # ----- X OAuth2 -----
+# Create an app at https://developer.x.com and enable OAuth2 with PKCE.
 X_CLIENT_ID=
 X_CLIENT_SECRET=
 X_REDIRECT_URI=http://localhost:3000/auth/x/callback
@@ -19,12 +22,13 @@ X_SCOPES=tweet.read users.read like.read bookmark.read offline.access
 
 # ----- LLM (default: openrouter) -----
 LLM_PROVIDER=openrouter
-OPENROUTER_API_KEY=          # required
+OPENROUTER_API_KEY=
 OPENROUTER_MODEL=anthropic/claude-sonnet-4.5
 
 # ----- Article extractor (default: firecrawl) -----
 EXTRACTOR=firecrawl
 FIRECRAWL_API_KEY=
+FIRECRAWL_BASE_URL=https://api.firecrawl.dev
 
 # ----- Crypto / sessions -----
 # 32 bytes, base64. Generate: bun -e "console.log(crypto.getRandomValues(new Uint8Array(32)).toBase64())"

--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ REDIS_URL=redis://localhost:6379
 X_CLIENT_ID=
 X_CLIENT_SECRET=
 X_REDIRECT_URI=http://localhost:3000/auth/x/callback
-X_SCOPES=tweet.read users.read like.read bookmark.read offline.access
+X_SCOPES="tweet.read users.read like.read bookmark.read offline.access"
 
 # ----- LLM (default: openrouter) -----
 LLM_PROVIDER=openrouter

--- a/README.md
+++ b/README.md
@@ -1,0 +1,72 @@
+# x-reporter
+
+Per-user X (Twitter) likes/bookmarks digest service. On a per-user schedule,
+x-reporter pulls a user's likes and bookmarks, extracts URLs/articles
+referenced in them, fetches and cleans the article content, then uses an LLM
+(orchestrated via LangGraph) to produce a personalized digest. Digests are
+persisted in Appwrite and exposed via REST.
+
+Runtime: Bun. Framework: NestJS. Queue: BullMQ + Redis. Storage: Appwrite.
+
+## Quickstart
+
+```sh
+# 1. Clone
+git clone https://github.com/fusuyfusuy/x-reporter.git
+cd x-reporter
+
+# 2. Install deps
+bun install
+
+# 3. Configure env
+cp .env.example .env
+# Fill in: APPWRITE_*, X_CLIENT_ID/SECRET, OPENROUTER_API_KEY,
+#          FIRECRAWL_API_KEY, TOKEN_ENC_KEY, SESSION_SECRET.
+# See docs/configuration.md for how to generate the crypto material.
+
+# 4. Bring up Redis
+docker compose up -d
+
+# 5. Bootstrap Appwrite collections, then run the dev server
+bun run setup:appwrite
+bun run start:dev
+```
+
+Visit `http://localhost:3000/auth/x/start` to begin the OAuth flow.
+
+> Appwrite is not included in the compose file because its stack is large
+> and evolves independently. Point `APPWRITE_ENDPOINT` at
+> [Appwrite Cloud](https://cloud.appwrite.io/v1), or self-host per the
+> [official instructions](https://appwrite.io/docs/advanced/self-hosting).
+
+## Scripts
+
+| Script                    | What it does                                  |
+|---------------------------|-----------------------------------------------|
+| `bun run start`           | Run the API + workers                         |
+| `bun run start:dev`       | Run with `--watch` for local dev              |
+| `bun run build`           | Bundle to `dist/` with Bun's bundler          |
+| `bun test`                | Run unit + e2e tests                          |
+| `bun run lint`            | Biome lint                                    |
+| `bun run format`          | Biome format (write)                          |
+| `bun run typecheck`       | `tsc --noEmit`                                |
+| `bun run setup:appwrite`  | Create Appwrite database + collections        |
+
+## Project structure
+
+- `src/` — NestJS application (modules per domain: `auth`, `ingestion`, `extraction`, `digest`, `queue`, `schedule`, `tokens`, `users`, `digests`, `workers`, `appwrite`, `health`, `common`, `config`)
+- `scripts/` — one-off operational scripts (`setup-appwrite.ts`)
+- `docs/` — architecture, data model, API, jobs, LLM graph, interfaces, configuration
+- `docker-compose.yml` — local Redis for BullMQ
+- `.env.example` — every env var the app reads, grouped by section
+
+## Docs
+
+- [docs/configuration.md](./docs/configuration.md) — env vars, secrets, local dev
+- [docs/architecture.md](./docs/architecture.md) — stack, modules, data flow
+- [docs/api.md](./docs/api.md) — REST surface, auth flow, payload shapes
+- [docs/jobs.md](./docs/jobs.md) — BullMQ queues, job payloads, retry policy
+- [docs/data-model.md](./docs/data-model.md) — Appwrite collections, fields, indexes
+- [docs/llm-and-graph.md](./docs/llm-and-graph.md) — LangGraph nodes + prompts
+- [docs/interfaces.md](./docs/interfaces.md) — `XSource` / `ArticleExtractor` / `LlmProvider` swap-points
+- [docs/README.md](./docs/README.md) — docs index

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+# docker-compose.yml
+#
+# Local dev stack for x-reporter.
+#
+# This compose file brings up Redis (required by BullMQ / `QueueModule`).
+#
+# Appwrite is intentionally NOT bundled here. Appwrite ships a multi-service
+# compose stack (~15 containers: mariadb, traefik, multiple workers, etc.)
+# that is too heavy to inline and evolves independently. Install Appwrite
+# per the official self-hosting docs:
+#
+#   https://appwrite.io/docs/advanced/self-hosting
+#
+# Or point `APPWRITE_ENDPOINT` at Appwrite Cloud (https://cloud.appwrite.io/v1)
+# and skip self-hosting entirely.
+#
+# Usage:
+#   docker compose up -d        # start Redis
+#   docker compose ps           # check health
+#   docker compose logs -f redis
+#   docker compose down         # stop (volumes persist)
+#   docker compose down -v      # stop + wipe data
+
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: x-reporter-redis
+    restart: unless-stopped
+    command: ["redis-server", "--appendonly", "yes"]
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+
+volumes:
+  redis-data:
+    name: x-reporter-redis-data


### PR DESCRIPTION
## Summary

- Add `docker-compose.yml` at repo root with a healthchecked `redis:7-alpine` service (BullMQ backend) and a named volume for persistence. Appwrite is deliberately not bundled — its stack is too heavy; the compose file and README point at Appwrite Cloud / the official self-hosting docs.
- Add a top-level `README.md` with project description, a 5-step quickstart that mirrors `docs/configuration.md`, a scripts table, a project-structure outline, and links into every doc under `docs/`.
- Round out `.env.example` so it matches `src/config/env.ts` exactly: adds `FIRECRAWL_BASE_URL` (default), keeps the generation commands for `TOKEN_ENC_KEY` / `SESSION_SECRET`, and groups vars by section (Server / Appwrite / Redis / X OAuth / LLM / Extractor / Crypto / Concurrency).

## Test plan

- [x] `bun test` — 382 pass, same 1 pre-existing failure on `main` (Redis-required test, unrelated to this PR).
- [x] `.env.example` cross-checked against every key in `src/config/env.ts`.
- [ ] `docker compose up -d` locally brings up Redis, `redis-cli ping` returns `PONG`, and `REDIS_URL=redis://localhost:6379 bun run start:dev` boots without Redis errors.

Closes #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive project README with architecture, quickstart, runtime scripts, and docs index.
  * Clarified configuration and setup guidance (Appwrite endpoints, Redis URL scheme, OAuth2 setup, scope formatting, OpenRouter key expectations).
  * Introduced default article-extractor base URL.

* **Chores**
  * Added Docker Compose for local Redis with persistence and healthchecks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->