### PR TITLE
test: e2e smoke + URL extraction unit tests (#12)

### DIFF
--- a/src/app.module.test.ts
+++ b/src/app.module.test.ts
@@ -4,12 +4,31 @@ import { Test } from '@nestjs/testing';
 import { AppModule } from './app.module';
 import { SESSION_COOKIE_NAME } from './auth/auth.controller';
 import { signCookieValue } from './auth/cookies';
-import { REDIS_HEALTH, type RedisHealthPort } from './queue/queue.tokens';
+import { LLM_PROVIDER } from './digest/llm/llm.tokens';
+import type {
+  ChatOptions,
+  ChatResult,
+  LlmProvider,
+} from './digest/llm/llm-provider.interface';
+import { ARTICLE_EXTRACTOR } from './extraction/extraction.module';
+import type {
+  ArticleExtractor,
+  ExtractedArticle,
+} from './extraction/article-extractor.port';
+import { X_SOURCE } from './ingestion/ingestion.module';
+import type { FetchPage, XSource } from './ingestion/x-source.port';
+import {
+  BUILD_DIGEST_QUEUE,
+  REDIS_HEALTH,
+  type RedisHealthPort,
+} from './queue/queue.tokens';
 import { ScheduleService } from './schedule/schedule.service';
 import { WorkersLifecycle } from './workers/workers.module';
 
 const TEST_SESSION_SECRET = 'a-test-session-secret-at-least-32-chars-long';
 const TEST_USER_ID = 'u_e2e_test_abc';
+const OTHER_USER_ID = 'u_e2e_test_other';
+const OTHER_USER_DIGEST_ID = 'd_cross_user';
 
 /**
  * In-memory `AppwriteService` stand-in for the e2e-lite test.
@@ -52,14 +71,44 @@ function makeStubAppwrite(): {
     }): Promise<Record<string, unknown> & { $id: string }>;
   };
 } {
-  const docs = new Map<string, Record<string, unknown> & { $id: string }>();
+  // Per-collection document store so /me and /digests don't share a
+  // single flat id namespace. Appwrite's SDK keys by (collection, id)
+  // and we need the same isolation here so the user-profile row and a
+  // digests row can coexist without the collection-scoped reads mixing
+  // them up.
+  const collections = new Map<string, Map<string, Record<string, unknown> & { $id: string }>>();
+  function getCollection(
+    id: string,
+  ): Map<string, Record<string, unknown> & { $id: string }> {
+    let coll = collections.get(id);
+    if (!coll) {
+      coll = new Map();
+      collections.set(id, coll);
+    }
+    return coll;
+  }
   // Pre-seed the test user so /me has something to read.
-  docs.set(TEST_USER_ID, {
+  getCollection('users').set(TEST_USER_ID, {
     $id: TEST_USER_ID,
     xUserId: '999999',
     handle: 'e2e_user',
     status: 'active',
     createdAt: '2026-04-06T12:00:00Z',
+  });
+  // Pre-seed a digest row owned by a DIFFERENT user so the cross-user
+  // 404 test can try to fetch it with TEST_USER_ID's cookie and
+  // confirm the service/repo collapses "not yours" to a 404.
+  getCollection('digests').set(OTHER_USER_DIGEST_ID, {
+    $id: OTHER_USER_DIGEST_ID,
+    userId: OTHER_USER_ID,
+    windowStart: '2026-04-05T00:00:00.000Z',
+    windowEnd: '2026-04-06T00:00:00.000Z',
+    markdown: '## private\n',
+    itemIds: ['i_other'],
+    model: 'anthropic/claude-sonnet-4.5',
+    tokensIn: 1,
+    tokensOut: 2,
+    createdAt: '2026-04-06T00:05:00.000Z',
   });
   return {
     databaseId: 'xreporter_test',
@@ -68,7 +117,7 @@ function makeStubAppwrite(): {
     },
     databases: {
       async getDocument(p) {
-        const doc = docs.get(p.documentId);
+        const doc = getCollection(p.collectionId).get(p.documentId);
         if (!doc) {
           const err = new Error('not found') as Error & { code: number };
           err.code = 404;
@@ -77,24 +126,154 @@ function makeStubAppwrite(): {
         return doc;
       },
       async updateDocument(p) {
-        const existing = docs.get(p.documentId);
+        const coll = getCollection(p.collectionId);
+        const existing = coll.get(p.documentId);
         if (!existing) {
           const err = new Error('not found') as Error & { code: number };
           err.code = 404;
           throw err;
         }
         const updated = { ...existing, ...p.data };
-        docs.set(p.documentId, updated);
+        coll.set(p.documentId, updated);
         return updated;
       },
-      async listDocuments() {
-        return { total: 0, documents: [] };
+      async listDocuments(p) {
+        // Lightweight `Query.equal("userId", ...)` support —
+        // DigestsRepo.listByUser uses that filter to scope results. If
+        // we don't honor it here the cross-user digest would surface in
+        // TEST_USER_ID's list response. Appwrite's `Query.equal()`
+        // serializes to a JSON string of the form
+        // `{"method":"equal","attribute":"userId","values":["<id>"]}`
+        // — see `src/workers/digests.repo.test.ts` for the same
+        // parser shape.
+        const coll = getCollection(p.collectionId);
+        const queries = p.queries ?? [];
+        const filters: Array<[string, string]> = [];
+        for (const q of queries) {
+          try {
+            const parsed = JSON.parse(q) as {
+              method?: string;
+              attribute?: string;
+              values?: unknown[];
+            };
+            if (parsed.method === 'equal') {
+              filters.push([
+                String(parsed.attribute),
+                String((parsed.values ?? [])[0]),
+              ]);
+            }
+            // orderDesc / limit / cursorAfter are ignored: the e2e-lite
+            // run only asserts list size and userId-scoping.
+          } catch {
+            // Non-JSON queries (legacy format) — fall back to ignoring.
+          }
+        }
+        const all = [...coll.values()];
+        const filtered = all.filter((d) =>
+          filters.every(([field, value]) => String(d[field]) === value),
+        );
+        return { total: filtered.length, documents: filtered };
       },
       async createDocument(p) {
         const doc = { $id: p.documentId, ...p.data };
-        docs.set(p.documentId, doc);
+        getCollection(p.collectionId).set(p.documentId, doc);
         return doc;
       },
+    },
+  };
+}
+
+/**
+ * In-memory `BUILD_DIGEST_QUEUE` producer. `DigestsService.enqueueRunNow`
+ * only calls `.add(name, data, opts)` and reads `.id` off the result;
+ * nothing in the e2e-lite run actually drains the queue. Recording each
+ * add lets the `POST /digests/run-now` test assert the enqueue happened
+ * without spinning up a real BullMQ worker.
+ */
+function makeStubBuildDigestQueue(): {
+  add(
+    name: string,
+    data: unknown,
+    opts?: Record<string, unknown>,
+  ): Promise<{ id: string }>;
+  adds: Array<{ name: string; data: unknown; opts?: Record<string, unknown> }>;
+} {
+  const adds: Array<{ name: string; data: unknown; opts?: Record<string, unknown> }> = [];
+  let next = 1;
+  return {
+    adds,
+    async add(name, data, opts) {
+      const entry: { name: string; data: unknown; opts?: Record<string, unknown> } = {
+        name,
+        data,
+      };
+      if (opts !== undefined) entry.opts = opts;
+      adds.push(entry);
+      return { id: `job-${next++}` };
+    },
+  };
+}
+
+/**
+ * Canned `XSource`. Returns a deterministic single-page response for
+ * both endpoints so any worker path that happens to reach the port in
+ * e2e-lite sees the same bytes, not an "undefined is not a function"
+ * style crash. No worker is wired to actually run here — the stub
+ * exists to satisfy DI for `WorkersModule.forRoot`.
+ */
+function makeStubXSource(): XSource {
+  const page: FetchPage = {
+    items: [
+      {
+        tweetId: 't_stub_1',
+        text: 'hello https://example.com/stub',
+        authorHandle: 'stub_author',
+        urls: ['https://example.com/stub'],
+        kind: 'like',
+      },
+    ],
+  };
+  return {
+    async fetchLikes() {
+      return page;
+    },
+    async fetchBookmarks() {
+      return { items: [] };
+    },
+  };
+}
+
+/**
+ * Canned `ArticleExtractor`. Mirrors the shape the real adapters return
+ * so any DI resolution path during e2e-lite bootstrap sees a valid
+ * `ExtractedArticle` instead of a test-double shaped object.
+ */
+function makeStubArticleExtractor(): ArticleExtractor {
+  return {
+    async extract(url: string): Promise<ExtractedArticle> {
+      return {
+        url,
+        title: 'Stub Article',
+        siteName: 'Stub Site',
+        content: 'Stub markdown body.',
+        extractor: 'stub',
+      };
+    },
+  };
+}
+
+/**
+ * Canned `LlmProvider`. Returns an empty JSON envelope for any prompt
+ * so the DI graph resolves; no digest graph runs during e2e-lite.
+ */
+function makeStubLlmProvider(): LlmProvider {
+  return {
+    model: 'stub/e2e',
+    async chat(_opts: ChatOptions): Promise<ChatResult> {
+      return {
+        content: '{"clusters":[]}',
+        usage: { tokensIn: 0, tokensOut: 0 },
+      };
     },
   };
 }
@@ -102,6 +281,7 @@ function makeStubAppwrite(): {
 describe('AppModule (e2e-lite)', () => {
   let app: INestApplication;
   let baseUrl: string;
+  let stubBuildDigestQueue: ReturnType<typeof makeStubBuildDigestQueue>;
 
   beforeAll(async () => {
     // Force test env so the logger is silent.
@@ -172,6 +352,8 @@ describe('AppModule (e2e-lite)', () => {
       },
     };
 
+    stubBuildDigestQueue = makeStubBuildDigestQueue();
+
     const moduleRef = await Test.createTestingModule({
       imports: [AppModule.forRoot()],
     })
@@ -185,6 +367,21 @@ describe('AppModule (e2e-lite)', () => {
       // Redis. Override with a no-op so the e2e-lite test works offline.
       .overrideProvider(WorkersLifecycle)
       .useValue({ onModuleInit() {}, async onModuleDestroy() {} })
+      // Override the BullMQ producer so `POST /digests/run-now` can
+      // enqueue without a live Redis. The structural type in
+      // `DigestsService` only needs `.add(name, data, opts)`.
+      .overrideProvider(BUILD_DIGEST_QUEUE)
+      .useValue(stubBuildDigestQueue)
+      // Stub the four swap-point adapters so the DI graph resolves
+      // under `WorkersModule.forRoot` / `DigestGraphModule` without
+      // reaching out to X, Firecrawl, or OpenRouter. None of these
+      // run during e2e-lite; they exist solely to satisfy DI.
+      .overrideProvider(X_SOURCE)
+      .useValue(makeStubXSource())
+      .overrideProvider(ARTICLE_EXTRACTOR)
+      .useValue(makeStubArticleExtractor())
+      .overrideProvider(LLM_PROVIDER)
+      .useValue(makeStubLlmProvider())
       .compile();
 
     app = moduleRef.createNestApplication();
@@ -339,5 +536,119 @@ describe('AppModule (e2e-lite)', () => {
     const cookieHeader = `${SESSION_COOKIE_NAME}=${encodeURIComponent(sessionValue)}`;
     const res = await fetch(`${baseUrl}/me`, { headers: { cookie: cookieHeader } });
     expect(res.status).toBe(401);
+  });
+
+  // ---------------------------------------------------------------------
+  // /digests e2e coverage (issue #12).
+  //
+  // The acceptance criteria for this block is "full HTTP surface of
+  // `/digests` goes through the real controller/service/repo with
+  // stubbed ports". We use the same session-cookie + stub-Appwrite
+  // pattern as /me so the full session guard → controller → service →
+  // repo → (stub) DB round-trip is exercised.
+  //
+  // Intentional non-goals:
+  //   - We do NOT drain the build-digest queue; the stub producer
+  //     records adds and returns a jobId, that's enough to assert
+  //     `POST /digests/run-now` is wired end-to-end.
+  //   - We do NOT run the DigestGraph — the graph is covered by unit
+  //     tests (see `src/digest/graph/digest.graph.test.ts`).
+  // ---------------------------------------------------------------------
+
+  function testCookie(): string {
+    const sessionValue = signCookieValue(
+      { userId: TEST_USER_ID, issuedAt: Date.now() },
+      TEST_SESSION_SECRET,
+    );
+    return `${SESSION_COOKIE_NAME}=${encodeURIComponent(sessionValue)}`;
+  }
+
+  it('GET /digests without a session cookie returns 401', async () => {
+    const res = await fetch(`${baseUrl}/digests`);
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe('unauthorized');
+  });
+
+  it('GET /digests/:id without a session cookie returns 401', async () => {
+    const res = await fetch(`${baseUrl}/digests/any-id`);
+    expect(res.status).toBe(401);
+  });
+
+  it('POST /digests/run-now without a session cookie returns 401', async () => {
+    const res = await fetch(`${baseUrl}/digests/run-now`, { method: 'POST' });
+    expect(res.status).toBe(401);
+  });
+
+  it('GET /digests returns an empty list when the user has no digests', async () => {
+    // The stub Appwrite pre-seeds a digest belonging to OTHER_USER_ID,
+    // so a correctly-scoped list for TEST_USER_ID must exclude it and
+    // return `{ items: [] }`. This doubles as a cross-user isolation
+    // check on the list endpoint.
+    const res = await fetch(`${baseUrl}/digests`, {
+      headers: { cookie: testCookie() },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { items: unknown[]; nextCursor?: string };
+    expect(body.items).toEqual([]);
+    expect(body.nextCursor).toBeUndefined();
+  });
+
+  it('GET /digests/:id returns 404 for a non-existent id', async () => {
+    const res = await fetch(`${baseUrl}/digests/d_does_not_exist`, {
+      headers: { cookie: testCookie() },
+    });
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe('not_found');
+  });
+
+  it('GET /digests/:id returns 404 when the id belongs to another user', async () => {
+    // Security check: the pre-seeded digest's userId is OTHER_USER_ID,
+    // but we call with TEST_USER_ID's cookie. The repo collapses
+    // "not yours" to the same "not found" signal the service returns
+    // for missing ids, so a probing client cannot distinguish "owned
+    // by someone else" from "doesn't exist".
+    const res = await fetch(`${baseUrl}/digests/${OTHER_USER_DIGEST_ID}`, {
+      headers: { cookie: testCookie() },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('POST /digests/run-now returns 202 with a jobId and enqueues exactly one build-digest job', async () => {
+    const before = stubBuildDigestQueue.adds.length;
+    const res = await fetch(`${baseUrl}/digests/run-now`, {
+      method: 'POST',
+      headers: { cookie: testCookie() },
+    });
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as { jobId: string; queuedAt: string };
+    expect(typeof body.jobId).toBe('string');
+    expect(body.jobId.length).toBeGreaterThan(0);
+    expect(typeof body.queuedAt).toBe('string');
+
+    // The producer stub was invoked exactly once, with the expected
+    // name + payload shape (see `DigestsService.enqueueRunNow`).
+    expect(stubBuildDigestQueue.adds.length).toBe(before + 1);
+    const lastAdd = stubBuildDigestQueue.adds[stubBuildDigestQueue.adds.length - 1];
+    if (!lastAdd) throw new Error('expected an enqueued build-digest job');
+    expect(lastAdd.name).toBe('build-digest');
+    expect(lastAdd.data).toEqual({ userId: TEST_USER_ID });
+    // Retry / removal policy is set by the service, not by BullMQ
+    // defaults. Assert the documented policy so a silent change is
+    // caught by this test.
+    expect(lastAdd.opts).toMatchObject({
+      attempts: 3,
+      backoff: { type: 'exponential', delay: 60_000 },
+    });
+  });
+
+  it('GET /digests rejects an invalid limit with 400 validation_failed', async () => {
+    const res = await fetch(`${baseUrl}/digests?limit=0`, {
+      headers: { cookie: testCookie() },
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: { code?: string } };
+    expect(body.error?.code).toBe('validation_failed');
   });
 });

--- a/src/digest/graph/digest.graph.test.ts
+++ b/src/digest/graph/digest.graph.test.ts
@@ -192,4 +192,108 @@ describe('DigestGraph', () => {
     // cluster + 2 summarize + rank + compose = 5
     expect(stub.calls).toHaveLength(5);
   });
+
+  it('orders compose input by rank score, descending, regardless of cluster order', async () => {
+    // This pins the rank-node ordering contract: even when the cluster
+    // node produces [High, Low] order, a low score for `High` + high
+    // score for `Low` should flip the order when compose receives the
+    // ranked list. The compose stub captures the prompt so we can
+    // inspect the prefix/position of each cluster in the input.
+    let capturedComposePrompt = '';
+    const stub = new StubLlmProvider({
+      handlers: [
+        {
+          match: (opts) =>
+            opts.messages[0]?.content.includes('Group the following items') ?? false,
+          respond: () =>
+            JSON.stringify({
+              clusters: [
+                { topic: 'Alpha', itemIds: ['i1'] },
+                { topic: 'Bravo', itemIds: ['i2'] },
+                { topic: 'Charlie', itemIds: ['i3'] },
+              ],
+            }),
+        },
+        {
+          match: (opts) => opts.messages[0]?.content.includes('Topic: Alpha') ?? false,
+          respond: () =>
+            JSON.stringify({
+              summary: 'Alpha summary.',
+              highlights: ['a1', 'a2', 'a3'],
+            }),
+        },
+        {
+          match: (opts) => opts.messages[0]?.content.includes('Topic: Bravo') ?? false,
+          respond: () =>
+            JSON.stringify({
+              summary: 'Bravo summary.',
+              highlights: ['b1', 'b2', 'b3'],
+            }),
+        },
+        {
+          match: (opts) => opts.messages[0]?.content.includes('Topic: Charlie') ?? false,
+          respond: () =>
+            JSON.stringify({
+              summary: 'Charlie summary.',
+              highlights: ['c1', 'c2', 'c3'],
+            }),
+        },
+        {
+          match: (opts) => opts.messages[0]?.content.includes('Score each cluster') ?? false,
+          // Invert: Alpha=2, Bravo=9, Charlie=5 → expected ranked order Bravo, Charlie, Alpha
+          respond: () =>
+            JSON.stringify({
+              scores: [
+                { id: 'c0', score: 2 },
+                { id: 'c1', score: 9 },
+                { id: 'c2', score: 5 },
+              ],
+            }),
+        },
+        {
+          match: (opts) =>
+            opts.messages[0]?.content.includes('Compose a personalized digest') ?? false,
+          respond: (opts) => {
+            capturedComposePrompt = opts.messages[0]?.content ?? '';
+            // Emit minimal markdown that matches ordering so we can
+            // also verify the result.markdown surfaces that order.
+            return '## Bravo\n\nBravo body.\n\n## Charlie\n\nCharlie body.\n\n## Alpha\n\nAlpha body.\n';
+          },
+        },
+      ],
+    });
+
+    const graph = new DigestGraph(stub);
+    const result = await graph.run({
+      userId: 'u',
+      window: { start: new Date(), end: new Date() },
+      items: makeItems(),
+    });
+
+    // The compose prompt lists clusters using "### N. Topic (score=..." —
+    // verify the positional ordering matches rank-descending.
+    const bravoIdx = capturedComposePrompt.indexOf('### 1. Bravo');
+    const charlieIdx = capturedComposePrompt.indexOf('### 2. Charlie');
+    const alphaIdx = capturedComposePrompt.indexOf('### 3. Alpha');
+    expect(bravoIdx).toBeGreaterThanOrEqual(0);
+    expect(charlieIdx).toBeGreaterThan(bravoIdx);
+    expect(alphaIdx).toBeGreaterThan(charlieIdx);
+    // Scores surface in the prompt too.
+    expect(capturedComposePrompt).toContain('(score=9)');
+    expect(capturedComposePrompt).toContain('(score=5)');
+    expect(capturedComposePrompt).toContain('(score=2)');
+
+    // Final markdown reflects rank ordering: Bravo, then Charlie, then Alpha.
+    const mdBravoIdx = result.markdown.indexOf('## Bravo');
+    const mdCharlieIdx = result.markdown.indexOf('## Charlie');
+    const mdAlphaIdx = result.markdown.indexOf('## Alpha');
+    expect(mdBravoIdx).toBeGreaterThanOrEqual(0);
+    expect(mdCharlieIdx).toBeGreaterThan(mdBravoIdx);
+    expect(mdAlphaIdx).toBeGreaterThan(mdCharlieIdx);
+
+    // All three items still surface on the result.
+    expect(result.itemIds).toEqual(['i1', 'i2', 'i3']);
+    // cluster + 3 summarize + rank + compose = 6 calls
+    expect(stub.calls).toHaveLength(6);
+  });
 });

--- a/src/ingestion/url-extractor.test.ts
+++ b/src/ingestion/url-extractor.test.ts
@@ -145,6 +145,75 @@ describe('extractUrls — entities.urls precedence', () => {
   });
 });
 
+describe('extractUrls — edge cases', () => {
+  it('returns [] for empty tweet text with no entities', () => {
+    expect(extractUrls({ text: '' })).toEqual([]);
+  });
+
+  it('returns [] for empty text with an empty entities.urls array (no fallthrough)', () => {
+    // Guards the invariant: even with zero-length entities.urls,
+    // the text-fallback branch is only taken when entities is missing
+    // OR the list is empty — in the empty case we fall through to text
+    // regex, and the empty text yields [].
+    expect(extractUrls({ text: '', entities: { urls: [] } })).toEqual([]);
+  });
+
+  it('preserves query strings and fragments on text-fallback URLs', () => {
+    const result = extractUrls({
+      text: 'see https://example.com/a?b=1&c=2#section and done',
+    });
+    expect(result).toEqual(['https://example.com/a?b=1&c=2#section']);
+  });
+
+  it('preserves query strings and fragments on entities expanded URLs', () => {
+    const result = extractUrls({
+      text: 'ignored',
+      entities: {
+        urls: [
+          {
+            url: 'https://t.co/x',
+            expanded_url: 'https://example.com/path?foo=bar#frag',
+          },
+        ],
+      },
+    });
+    expect(result).toEqual(['https://example.com/path?foo=bar#frag']);
+  });
+
+  it('handles internationalized domain names (percent-encoded)', () => {
+    // IDNs typically arrive percent-encoded (xn-- form or %xx) from X.
+    // The extractor is a pass-through — no URL normalization happens at
+    // this layer beyond t.co filtering + dedupe + sort.
+    const result = extractUrls({
+      text: 'look at https://xn--bcher-kva.example/page and https://example.com/%E4%B8%AD',
+    });
+    expect(result).toEqual([
+      'https://example.com/%E4%B8%AD',
+      'https://xn--bcher-kva.example/page',
+    ]);
+  });
+
+  it('mixes expanded and t.co entries: keeps expanded, drops bare t.co wrappers', () => {
+    // Documented entities branch behavior: when expanded_url is missing
+    // and the raw `url` is a t.co wrapper, the entry is filtered. When
+    // it's expanded, t.co is never surfaced regardless of the raw url.
+    const result = extractUrls({
+      text: 'ignored',
+      entities: {
+        urls: [
+          { url: 'https://t.co/keep', expanded_url: 'https://blog.example.com/a' },
+          { url: 'https://t.co/drop' }, // no expansion → dropped
+          { url: 'https://t.co/also', expanded_url: 'https://news.example.org/b' },
+        ],
+      },
+    });
+    expect(result).toEqual([
+      'https://blog.example.com/a',
+      'https://news.example.org/b',
+    ]);
+  });
+});
+
 describe('extractUrls — determinism', () => {
   it('returns the same result regardless of input order', () => {
     const a = extractUrls({


### PR DESCRIPTION
## Summary

- Extends `src/app.module.test.ts` with full HTTP-level coverage of the `/digests` surface: list (empty path), getById (404 for missing, 404 for cross-user — security isolation), run-now (202 + jobId + exactly-one enqueue with the documented retry policy), plus the 401 session-guard path on all three routes. Driven by in-memory stubs for `X_SOURCE`, `ARTICLE_EXTRACTOR`, `LLM_PROVIDER`, and `BUILD_DIGEST_QUEUE`, so no Redis / X / Firecrawl / OpenRouter is touched.
- Upgrades the stub `AppwriteService` in the e2e-lite test to a per-collection document store with JSON-query parsing (`Query.equal("userId", ...)`) so the cross-user 404 actually exercises the repo's `userId` filter rather than a bare `listDocuments` returning `[]`.
- Adds URL-extractor edge cases: empty text, query strings / fragments preserved on both branches, internationalized domains (percent-encoded + xn--), and mixed `expanded_url` / bare-`t.co` entity entries.
- Adds a `DigestGraph` rank-ordering test that pins the descending-score contract end-to-end: cluster node emits `[Alpha, Bravo, Charlie]`, rank node scores `[2, 9, 5]`, compose prompt and final markdown both surface them as `Bravo → Charlie → Alpha`.

No production code touched. The pre-existing `IngestionModule.forRoot` failure is unrelated and pre-dates this PR.

## Test plan

- [x] `bun test src/app.module.test.ts` — 16 pass
- [x] `bun test src/ingestion/url-extractor.test.ts` — 22 pass
- [x] `bun test src/digest/graph/digest.graph.test.ts` — 3 pass
- [x] `bun test` — 397 pass, 1 pre-existing unrelated fail
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx biome lint` on touched files — clean

Closes #12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end test coverage for digest endpoints with comprehensive HTTP test suite and validation assertions.
  * Enhanced test coverage for digest ordering and clustering behavior to verify expected processing workflows.
  * Added edge case tests for URL extraction to ensure proper handling of query strings, fragments, and internationalized domain names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->