### PR TITLE
fix(digests): prevent duplicate digests on BullMQ retry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x-reporter",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "type": "module",
   "description": "Per-user X likes/bookmarks digest service (Bun + NestJS)",

--- a/src/workers/digests.repo.test.ts
+++ b/src/workers/digests.repo.test.ts
@@ -151,6 +151,19 @@ describe('DigestsRepo.create', () => {
     const b = await repo2.create(BASE_INPUT);
     expect(a.id).toBe(b.id);
   });
+
+  it('treats type=document_already_exists (without code) as idempotent success', async () => {
+    const { repo, db } = makeRepo();
+    const first = await repo.create(BASE_INPUT);
+    db.createDocument = (async () => {
+      const err = new Error('Document already exists') as Error & { type: string };
+      err.type = 'document_already_exists';
+      throw err;
+    }) as FakeDatabases['createDocument'];
+    const second = await repo.create({ ...BASE_INPUT, markdown: '## different' });
+    expect(second.id).toBe(first.id);
+    expect(second.markdown).toBe('## hi');
+  });
 });
 
 describe('DigestsRepo.findByIdAndUser', () => {

--- a/src/workers/digests.repo.test.ts
+++ b/src/workers/digests.repo.test.ts
@@ -10,7 +10,6 @@ import { DigestsRepo } from './digests.repo';
  */
 class FakeDatabases {
   readonly docs = new Map<string, Record<string, unknown> & { $id: string }>();
-  private nextId = 1;
 
   async createDocument(params: {
     databaseId: string;
@@ -18,7 +17,12 @@ class FakeDatabases {
     documentId: string;
     data: Record<string, unknown>;
   }): Promise<Record<string, unknown> & { $id: string }> {
-    const id = `doc-${this.nextId++}`;
+    if (this.docs.has(params.documentId)) {
+      const err = new Error('Document already exists') as Error & { code: number };
+      err.code = 409;
+      throw err;
+    }
+    const id = params.documentId;
     const doc = { $id: id, ...params.data };
     this.docs.set(id, doc);
     return doc;
@@ -56,10 +60,7 @@ class FakeDatabases {
       };
       switch (parsed.method) {
         case 'equal':
-          filters.push([
-            String(parsed.attribute),
-            String((parsed.values ?? [])[0]),
-          ]);
+          filters.push([String(parsed.attribute), String((parsed.values ?? [])[0])]);
           break;
         case 'orderDesc':
           orderAttr = String(parsed.attribute);
@@ -133,6 +134,23 @@ describe('DigestsRepo.create', () => {
     const stored = db.docs.get(result.id);
     expect(typeof stored?.createdAt).toBe('string');
   });
+
+  it('is idempotent — a second create with the same window returns the existing row', async () => {
+    const { repo, db } = makeRepo();
+    const first = await repo.create(BASE_INPUT);
+    const second = await repo.create({ ...BASE_INPUT, markdown: '## different' });
+    expect(second.id).toBe(first.id);
+    expect(second.markdown).toBe('## hi');
+    expect(db.docs.size).toBe(1);
+  });
+
+  it('uses a deterministic document id based on userId + window bounds', async () => {
+    const { repo: repo1 } = makeRepo();
+    const { repo: repo2 } = makeRepo();
+    const a = await repo1.create(BASE_INPUT);
+    const b = await repo2.create(BASE_INPUT);
+    expect(a.id).toBe(b.id);
+  });
 });
 
 describe('DigestsRepo.findByIdAndUser', () => {
@@ -161,15 +179,23 @@ describe('DigestsRepo.findByIdAndUser', () => {
 describe('DigestsRepo.listByUser', () => {
   it('returns rows newest first for the given user', async () => {
     const { repo } = makeRepo();
-    // Seed three rows with distinct createdAt via sequential awaits.
-    // FakeDatabases' createDocument stamps incrementing ids, and the
-    // repo writes `new Date().toISOString()` at insert time, so the
-    // rows end up ordered by insertion time.
-    const a = await repo.create(BASE_INPUT);
+    const a = await repo.create({
+      ...BASE_INPUT,
+      windowStart: '2026-04-01T00:00:00.000Z',
+      windowEnd: '2026-04-02T00:00:00.000Z',
+    });
     await new Promise((r) => setTimeout(r, 2));
-    const b = await repo.create(BASE_INPUT);
+    const b = await repo.create({
+      ...BASE_INPUT,
+      windowStart: '2026-04-02T00:00:00.000Z',
+      windowEnd: '2026-04-03T00:00:00.000Z',
+    });
     await new Promise((r) => setTimeout(r, 2));
-    const c = await repo.create(BASE_INPUT);
+    const c = await repo.create({
+      ...BASE_INPUT,
+      windowStart: '2026-04-03T00:00:00.000Z',
+      windowEnd: '2026-04-04T00:00:00.000Z',
+    });
 
     const result = await repo.listByUser({ userId: 'u1', limit: 10 });
     expect(result.items.map((i) => i.id)).toEqual([c.id, b.id, a.id]);
@@ -190,7 +216,11 @@ describe('DigestsRepo.listByUser', () => {
     const ids: string[] = [];
     for (let i = 0; i < 5; i++) {
       await new Promise((r) => setTimeout(r, 2));
-      const row = await repo.create(BASE_INPUT);
+      const row = await repo.create({
+        ...BASE_INPUT,
+        windowStart: `2026-04-0${i + 1}T00:00:00.000Z`,
+        windowEnd: `2026-04-0${i + 2}T00:00:00.000Z`,
+      });
       ids.push(row.id);
     }
     const expectedNewestFirst = [...ids].reverse();

--- a/src/workers/digests.repo.ts
+++ b/src/workers/digests.repo.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { ID, Query } from 'node-appwrite';
+import { Query } from 'node-appwrite';
 import { AppwriteService } from '../appwrite/appwrite.service';
 
 /**
@@ -84,26 +84,44 @@ export class DigestsRepo {
     this.db = appwrite.databases as unknown as DigestsDatabases;
   }
 
-  /** Persist one digest row and return the parsed record. */
+  /**
+   * Persist one digest row and return the parsed record.
+   * Uses a deterministic document ID derived from (userId, windowStart,
+   * windowEnd) so BullMQ retries are idempotent — a 409 conflict means
+   * the digest already exists and is treated as success.
+   */
   async create(input: CreateDigestInput): Promise<DigestRecord> {
+    const documentId = await digestDocumentId(input.userId, input.windowStart, input.windowEnd);
     const createdAt = new Date().toISOString();
-    const created = await this.db.createDocument({
-      databaseId: this.databaseId,
-      collectionId: COLLECTION_ID,
-      documentId: ID.unique(),
-      data: {
-        userId: input.userId,
-        windowStart: input.windowStart,
-        windowEnd: input.windowEnd,
-        markdown: input.markdown,
-        itemIds: input.itemIds,
-        model: input.model,
-        tokensIn: input.tokensIn,
-        tokensOut: input.tokensOut,
-        createdAt,
-      },
-    });
-    return toDigestRecord(created);
+    try {
+      const created = await this.db.createDocument({
+        databaseId: this.databaseId,
+        collectionId: COLLECTION_ID,
+        documentId,
+        data: {
+          userId: input.userId,
+          windowStart: input.windowStart,
+          windowEnd: input.windowEnd,
+          markdown: input.markdown,
+          itemIds: input.itemIds,
+          model: input.model,
+          tokensIn: input.tokensIn,
+          tokensOut: input.tokensOut,
+          createdAt,
+        },
+      });
+      return toDigestRecord(created);
+    } catch (err) {
+      if (isConflict(err)) {
+        const existing = await this.db.getDocument({
+          databaseId: this.databaseId,
+          collectionId: COLLECTION_ID,
+          documentId,
+        });
+        return toDigestRecord(existing);
+      }
+      throw err;
+    }
   }
 
   /**
@@ -112,10 +130,7 @@ export class DigestsRepo {
    * else — the controller collapses both to a 404 so callers cannot
    * probe for other users' digest ids.
    */
-  async findByIdAndUser(
-    digestId: string,
-    userId: string,
-  ): Promise<DigestRecord | null> {
+  async findByIdAndUser(digestId: string, userId: string): Promise<DigestRecord | null> {
     try {
       const doc = await this.db.getDocument({
         databaseId: this.databaseId,
@@ -166,6 +181,21 @@ export class DigestsRepo {
 function isNotFound(err: unknown): boolean {
   if (!err || typeof err !== 'object') return false;
   return (err as { code?: number }).code === 404;
+}
+
+function isConflict(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  return (err as { code?: number }).code === 409;
+}
+
+async function digestDocumentId(
+  userId: string,
+  windowStart: string,
+  windowEnd: string,
+): Promise<string> {
+  const hasher = new Bun.CryptoHasher('sha256');
+  hasher.update(`${userId}|${windowStart}|${windowEnd}`);
+  return hasher.digest('hex').slice(0, 32);
 }
 
 function toDigestRecord(doc: Record<string, unknown> & { $id: string }): DigestRecord {

--- a/src/workers/digests.repo.ts
+++ b/src/workers/digests.repo.ts
@@ -91,7 +91,7 @@ export class DigestsRepo {
    * the digest already exists and is treated as success.
    */
   async create(input: CreateDigestInput): Promise<DigestRecord> {
-    const documentId = await digestDocumentId(input.userId, input.windowStart, input.windowEnd);
+    const documentId = digestDocumentId(input.userId, input.windowStart, input.windowEnd);
     const createdAt = new Date().toISOString();
     try {
       const created = await this.db.createDocument({
@@ -185,14 +185,11 @@ function isNotFound(err: unknown): boolean {
 
 function isConflict(err: unknown): boolean {
   if (!err || typeof err !== 'object') return false;
-  return (err as { code?: number }).code === 409;
+  const e = err as { code?: number; type?: string };
+  return e.code === 409 || e.type === 'document_already_exists';
 }
 
-async function digestDocumentId(
-  userId: string,
-  windowStart: string,
-  windowEnd: string,
-): Promise<string> {
+function digestDocumentId(userId: string, windowStart: string, windowEnd: string): string {
   const hasher = new Bun.CryptoHasher('sha256');
   hasher.update(`${userId}|${windowStart}|${windowEnd}`);
   return hasher.digest('hex').slice(0, 32);


### PR DESCRIPTION
## Summary
- Derive deterministic document ID from `sha256(userId|windowStart|windowEnd)` instead of `ID.unique()` so BullMQ retries are idempotent
- Catch 409 conflict on create and return the existing row (Option A from #30)
- Add idempotency and deterministic-ID tests to `digests.repo.test.ts`
- Bump version to 0.10.1

## Acceptance Criteria
- [x] `DigestsRepo.create` uses deterministic document ID derived from `(userId, windowStart, windowEnd)`
- [x] 409 conflict on create is caught and treated as success (returns existing row)
- [x] No schema migration needed
- [x] Existing tests updated and passing
- [x] New idempotency tests added

## Test plan
- [x] `bun test src/workers/digests.repo.test.ts` — 9 tests pass including new idempotency tests
- [x] `bun test src/workers/build-digest.processor.test.ts` — 8 tests pass (no changes needed)
- [x] `bunx tsc --noEmit` — clean

Closes #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Digest creation is now idempotent and more reliable: repeated requests for the same user/time window return the existing digest instead of creating duplicates.

* **Tests**
  * Expanded tests to cover idempotent behavior, deterministic ID generation, conflict handling, and consistent listing/pagination.

* **Chores**
  * Version bumped to 0.10.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->